### PR TITLE
code style fix

### DIFF
--- a/src/main/scala/ch/epfl/ts/benchmark/marketSimulator/OrderFeeder.scala
+++ b/src/main/scala/ch/epfl/ts/benchmark/marketSimulator/OrderFeeder.scala
@@ -4,7 +4,7 @@ import ch.epfl.ts.component.{Component, StartSignal}
 import ch.epfl.ts.data.Currency._
 import ch.epfl.ts.data.Order
 
-case class LastOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double) extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class LastOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double) extends Order
 
 /**
  * Component used to send orders to the MarketSimulator for the MarketSimulatorBenchmark.

--- a/src/main/scala/ch/epfl/ts/component/persist/OrderPersistor.scala
+++ b/src/main/scala/ch/epfl/ts/component/persist/OrderPersistor.scala
@@ -20,7 +20,7 @@ object OrderType extends Enumeration {
 import ch.epfl.ts.component.persist.OrderType._
 
 
-case class PersistorOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double, val orderType: OrderType) extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class PersistorOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double, val orderType: OrderType) extends Order
 
 /**
  * Implementation of the Persistance trait for Order

--- a/src/main/scala/ch/epfl/ts/data/Messages.scala
+++ b/src/main/scala/ch/epfl/ts/data/Messages.scala
@@ -23,8 +23,6 @@ trait Streamable
  */
 case class Transaction(mid: Long, price: Double, volume: Double, timestamp: Long, whatC: Currency, withC: Currency, buyerId: Long, buyOrderId: Long, sellerId: Long, sellOrderId: Long) extends Streamable
 
-trait AskOrder
-trait BidOrder
 
 /**
  * Data Transfer Object representing a Order
@@ -36,28 +34,34 @@ trait BidOrder
  * @param volume
  * @param price
  */
-abstract class Order(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double) extends Streamable
+abstract class Order() extends Streamable {
+  def oid: Long
+  def uid: Long
+  def timestamp: Long
+  def whatC: Currency
+  def withC: Currency
+  def volume: Double
+  def price: Double
+}
 
-abstract class LimitOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+abstract class LimitOrder extends Order
 
-case class LimitBidOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends LimitOrder(oid, uid, timestamp, whatC, withC, volume, price) with BidOrder
+case class LimitBidOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends LimitOrder
 
-case class LimitAskOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends LimitOrder(oid, uid, timestamp, whatC, withC, volume, price) with AskOrder
+case class LimitAskOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends LimitOrder
 
-abstract class MarketOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+abstract class MarketOrder extends Order
 
-case class MarketBidOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends MarketOrder(oid, uid, timestamp, whatC, withC, volume, price) with BidOrder
+case class MarketBidOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends MarketOrder
 
-case class MarketAskOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends MarketOrder(oid, uid, timestamp, whatC, withC, volume, price) with AskOrder
+case class MarketAskOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends MarketOrder
 
-case class DelOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class DelOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends Order
 
 
 /**

--- a/src/main/scala/ch/epfl/ts/engine/Messages.scala
+++ b/src/main/scala/ch/epfl/ts/engine/Messages.scala
@@ -13,22 +13,22 @@ import ch.epfl.ts.data.Order
  */
 
 /* Answer */
-case class AcceptedOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class AcceptedOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends Order
 
 object AcceptedOrder {
   def apply(o: Order): AcceptedOrder = AcceptedOrder(o.oid, o.uid, o.timestamp, o.whatC, o.withC, o.volume, o.price)
 }
 
-case class RejectedOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class RejectedOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends Order
 
 object RejectedOrder {
   def apply(o: Order): RejectedOrder = RejectedOrder(o.oid, o.uid, o.timestamp, o.whatC, o.withC, o.volume, o.price)
 }
 
-case class ExecutedOrder(override val oid: Long, override val uid: Long, override val timestamp: Long, override val whatC: Currency, override val withC: Currency, override val volume: Double, override val price: Double)
-  extends Order(oid, uid, timestamp, whatC, withC, volume, price)
+case class ExecutedOrder(val oid: Long, val uid: Long, val timestamp: Long, val whatC: Currency, val withC: Currency, val volume: Double, val price: Double)
+  extends Order
 
 object ExecutedOrder {
   def apply(o: Order): ExecutedOrder = ExecutedOrder(o.oid, o.uid, o.timestamp, o.whatC, o.withC, o.volume, o.price)


### PR DESCRIPTION
It's possible in Scala to make the syntax a little lighter. The trick is that you can override `def` with `val`, but not vice versa.
