### PR TITLE
style fix: use case object for parameterless case classes

### DIFF
--- a/src/main/scala/ch/epfl/ts/benchmark/marketSimulator/OrderFeeder.scala
+++ b/src/main/scala/ch/epfl/ts/benchmark/marketSimulator/OrderFeeder.scala
@@ -14,7 +14,7 @@ case class LastOrder(val oid: Long, val uid: Long, val timestamp: Long, val what
 class OrderFeeder(orders: List[Order]) extends Component {
 
   def receiver = {
-    case StartSignal() => {
+    case StartSignal => {
       val ordersSent = orders :+ LastOrder(0L, 0L, System.currentTimeMillis(), DEF, DEF, 0.0, 0.0)
       send(StartSending(orders.size))
       ordersSent.map { o => send(o) }

--- a/src/main/scala/ch/epfl/ts/benchmark/scala/BenchmarkCommands.scala
+++ b/src/main/scala/ch/epfl/ts/benchmark/scala/BenchmarkCommands.scala
@@ -5,7 +5,7 @@ import ch.epfl.ts.data.{Order, Transaction}
 
 case class Start(offset: Long)
 
-case class Stop()
+case object Stop
 
 case class Report(source: String, startTime: Long, endTime: Long)
 

--- a/src/main/scala/ch/epfl/ts/benchmark/scala/FetchActors.scala
+++ b/src/main/scala/ch/epfl/ts/benchmark/scala/FetchActors.scala
@@ -17,7 +17,7 @@ abstract class TimedReporterActor(master: ActorRef, dest: List[ActorRef], source
     case RunItNow => readAndSend
   }
 
-  case class RunItNow()
+  case object RunItNow
 
   def readAndSend: Unit = {
     val startTime = System.currentTimeMillis

--- a/src/main/scala/ch/epfl/ts/component/Component.scala
+++ b/src/main/scala/ch/epfl/ts/component/Component.scala
@@ -7,8 +7,8 @@ import scala.reflect.ClassTag
 import scala.language.existentials
 import scala.collection.mutable.{HashMap => MHashMap}
 
-case class StartSignal()
-case class StopSignal()
+case object StartSignal
+case object StopSignal
 case class ComponentRegistration(ar: ActorRef, ct: Class[_], name: String)
 
 final class ComponentBuilder(name: String) {
@@ -26,12 +26,12 @@ final class ComponentBuilder(name: String) {
   def add(src: ComponentRef, dest: ComponentRef) = (src, dest, classOf[Any])
 
   def start = instances.map(cr => {
-    cr.ar ! new StartSignal()
+    cr.ar ! StartSignal
     println("Sending start Signal to " + cr.ar)
   })
   
   def stop = instances.map { cr => {
-    cr.ar ! new StopSignal()
+    cr.ar ! StopSignal
     println("Sending stop Signal to " + cr.ar)
   } }
 
@@ -66,11 +66,11 @@ abstract class Component extends Receiver {
       dest += (ct -> (ar :: dest.getOrElse(ct, List())))
       destName += (name -> ar)
       println("Received destination " + this.getClass.getSimpleName + ": from " + ar + " to " + ct.getSimpleName)
-    case s: StartSignal => stopped = false
-      receiver(s)
+    case StartSignal => stopped = false
+      receiver(StartSignal)
       println("Received Start " + this.getClass.getSimpleName)
-    case s: StopSignal => context.stop(self)
-      receiver(s)
+    case StopSignal => context.stop(self)
+      receiver(StopSignal)
       println("Received Stop " + this.getClass.getSimpleName)
     case y if stopped => println("Received data when stopped " + this.getClass.getSimpleName + " of type " + y.getClass )
   }

--- a/src/main/scala/ch/epfl/ts/engine/MarketSimulator.scala
+++ b/src/main/scala/ch/epfl/ts/engine/MarketSimulator.scala
@@ -8,8 +8,9 @@ import ch.epfl.ts.data.Currency.Currency
  * Base class for all market simulators.
  * Defines the interface and common behaviors.
  */
+
 abstract class MarketSimulator(marketId: Long, rules: MarketRules) extends Component {
-  
+
   /**
    * Format:
    *   (currency sold, currency bought) --> (bid price, ask price)

--- a/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
+++ b/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
@@ -8,7 +8,7 @@ import ch.epfl.ts.data._
 /**
  * Message used to print the books contents (since we use PriotityQueues, it's the heap order)
  */
-case class PrintBooks()
+case object PrintBooks
 
 
 class OrderBookMarketSimulator(marketId: Long, rules: MarketRules) extends MarketSimulator(marketId, rules) {

--- a/src/main/scala/ch/epfl/ts/engine/RevenueCompute.scala
+++ b/src/main/scala/ch/epfl/ts/engine/RevenueCompute.scala
@@ -10,27 +10,22 @@ abstract class RevenueCompute(traderNames: Map[Long, String]) extends Component 
 
  import context._
 
- //Important TODO : Wallet Component , 1 wallet per trader.
+  // TODO: Wallet Component , 1 wallet per trader.
  
-  case class Tick()
-   case class Wallet(var funds: Map[Currency.Value, Double])
+  case object Tick
+  case class Wallet(var funds: Map[Currency.Value, Double])
 
   var wallets = Map[Long, Wallet]()
   var oldTradingPrice: Double = 0.0
   var currentTradingPrice: Double = 0.0
 
-
   def process(t: Transaction)
-  
- 
- //TODO Better stats (when Wallet component is ready)
- def displayStats(traderId: Long) = {
+   
+  // TODO: Better stats (when Wallet component is ready)
+  def displayStats(traderId: Long) = {
     var disp = new StringBuffer()
     disp.append(f"Stats: trading price=$currentTradingPrice%s \n")
     disp.append("Stats: trader: " + traderNames(traderId) + ", cash=" + wallets(traderId).funds + "\n")
     print(disp)
   }
-
-
-
 }

--- a/src/main/scala/ch/epfl/ts/engine/RevenueComputeFX.scala
+++ b/src/main/scala/ch/epfl/ts/engine/RevenueComputeFX.scala
@@ -9,7 +9,6 @@ import ch.epfl.ts.data.Currency
 class RevenueComputeFX(traderNames: Map[Long, String]) extends RevenueCompute(traderNames) {
   /*
    * The revenue Compute for FX backtesting.
-   * 
    */
   
   //Simple , just to have a functional output

--- a/src/main/scala/ch/epfl/ts/engine/RevenueComputeSim.scala
+++ b/src/main/scala/ch/epfl/ts/engine/RevenueComputeSim.scala
@@ -22,28 +22,30 @@ class RevenueComputeSim(traderNames: Map[Long, String],pingIntervalMillis: Int) 
 
   def process(t: Transaction) = {
     currentTradingPrice = t.price
-    // buyer has more shares but less money
-     val buyerWallet = wallets.getOrElse(t.buyerId, Wallet(Map(Currency.USD -> 5000, Currency.EUR -> 0)))
-      buyerWallet.funds.get(t.withC) match {
+    
+    // Buyer has more shares but less money
+    val buyerWallet = wallets.getOrElse(t.buyerId, Wallet(Map(Currency.USD -> 5000, Currency.EUR -> 0)))
+    
+    buyerWallet.funds.get(t.withC) match {
         case Some(v) =>
           val newFund = v - t.volume * t.price
           buyerWallet.funds += (t.withC -> newFund)
         case None =>
           println("You can't trade those currencies")
+     }
+     buyerWallet.funds.get(t.whatC) match {
+       case Some(v) =>
+         val newFund = v + t.volume
+         buyerWallet.funds += (t.whatC -> newFund)
+       case None =>
+         println("You can't trade those currencies")
       }
-      buyerWallet.funds.get(t.whatC) match {
-        case Some(v) =>
-          val newFund = v + t.volume
-          buyerWallet.funds += (t.whatC -> newFund)
-        case None =>
-          println("You can't trade those currencies")
-
-      }
+     
       wallets += (t.buyerId -> buyerWallet)
 
-    // seller has more money but less shares
-       val sellerWallet = wallets.getOrElse(t.sellerId, Wallet(Map(Currency.USD -> 5000, Currency.EUR -> 0)))
-      sellerWallet.funds.get(t.withC) match {
+     // Seller has more money but less shares
+     val sellerWallet = wallets.getOrElse(t.sellerId, Wallet(Map(Currency.USD -> 5000, Currency.EUR -> 0)))
+     sellerWallet.funds.get(t.withC) match {
         case Some(v) =>
           val newFund = v + t.volume * t.price
           sellerWallet.funds += (t.withC -> newFund)

--- a/src/main/scala/ch/epfl/ts/traders/SimpleTrader.scala
+++ b/src/main/scala/ch/epfl/ts/traders/SimpleTrader.scala
@@ -7,7 +7,7 @@ import ch.epfl.ts.data.{MarketAskOrder, MarketBidOrder, Order}
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
-case class SendMarketOrder()
+case object SendMarketOrder
 
 /**
  * Simple trader that periodically sends market ask and bid orders alternatively.
@@ -21,7 +21,7 @@ class SimpleTrader(uid: Long, intervalMillis: Int, orderVolume: Double) extends 
   var alternate = 0
 
   override def receiver = {
-    case StartSignal() => start
+    case StartSignal     => start
     case SendMarketOrder => {
       if (alternate % 2 == 0) {
         println("SimpleTrader: sending market bid order")

--- a/src/main/scala/ch/epfl/ts/traders/SobiTrader.scala
+++ b/src/main/scala/ch/epfl/ts/traders/SobiTrader.scala
@@ -16,7 +16,7 @@ class SobiTrader(uid: Long, intervalMillis: Int, quartile: Int, theta: Double, o
   extends Component {
   import context._
 
-  case class PossibleOrder()
+  case object PossibleOrder
 
   val book = OrderBook(rules.bidsOrdering, rules.asksOrdering)
   var tradingPrice = 188700.0 // for finance.csv
@@ -26,14 +26,14 @@ class SobiTrader(uid: Long, intervalMillis: Int, quartile: Int, theta: Double, o
   var currentOrderId: Long = 456789
 
   override def receiver = {
-    case StartSignal()            => start
+    case StartSignal              => start
 
     case limitAsk: LimitAskOrder  => book insertAskOrder limitAsk
     case limitBid: LimitBidOrder  => book insertBidOrder limitBid
     case delete: DelOrder         => removeOrder(delete)
     case transaction: Transaction => tradingPrice = transaction.price
 
-    case b: PossibleOrder => {
+    case PossibleOrder => {
       bi = computeBiOrSi(book.bids.book)
       si = computeBiOrSi(book.asks.book)
       if ((si - bi) > theta) {
@@ -54,7 +54,7 @@ class SobiTrader(uid: Long, intervalMillis: Int, quartile: Int, theta: Double, o
   }
 
   def start = {
-    system.scheduler.schedule(0 milliseconds, intervalMillis milliseconds, self, PossibleOrder())
+    system.scheduler.schedule(0 milliseconds, intervalMillis milliseconds, self, PossibleOrder)
   }
 
   def removeOrder(order: Order): Unit = book delete order

--- a/src/main/scala/ch/epfl/ts/traders/TransactionVwapTrader.scala
+++ b/src/main/scala/ch/epfl/ts/traders/TransactionVwapTrader.scala
@@ -13,7 +13,7 @@ import scala.language.postfixOps
 class TransactionVwapTrader(uid: Long, timeFrameMillis: Int) extends Component {
   import context._
 
-  case class Tick()
+  case object Tick
 
   def priceOrdering = new Ordering[Transaction] {
     def compare(first: Transaction, second: Transaction): Int =
@@ -35,9 +35,9 @@ class TransactionVwapTrader(uid: Long, timeFrameMillis: Int) extends Component {
   val volumeToTrade = 50
 
   def receiver = {
-    case StartSignal()  => start
+    case StartSignal    => start
     case t: Transaction => transactions = t :: transactions
-    case Tick() => {
+    case Tick => {
       computeVWAP
       if (tradingPrice > vwap) {
         // sell
@@ -70,6 +70,6 @@ class TransactionVwapTrader(uid: Long, timeFrameMillis: Int) extends Component {
 
   def start = {
     println("TransactionVwapTrader: Started")
-    system.scheduler.schedule(0 milliseconds, timeFrameMillis milliseconds, self, Tick())
+    system.scheduler.schedule(0 milliseconds, timeFrameMillis milliseconds, self, Tick)
   }
 }


### PR DESCRIPTION
It's recommended to use `case object` to replace parameterless `case class`.
