### PR TITLE
Full market-simulation

### DIFF
--- a/ts/src/main/scala/ch/epfl/ts/component/Component.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/Component.scala
@@ -54,6 +54,7 @@ final class ComponentBuilder(val system: ActorSystem) {
 }
 
 /** Encapsulates [[akka.actor.ActorRef]] to facilitate connection of components
+  * TODO(sygi): support sending messages to ComponentRefs through !
   */
 class ComponentRef(val ar: ActorRef, val clazz: Class[_], val name: String, cb: ComponentBuilder) extends Serializable {
   /** Connects current component to the destination component
@@ -96,6 +97,7 @@ abstract class Component extends Receiver {
     case StopSignal => context.stop(self)
       stop
       println("Received Stop " + this.getClass.getSimpleName)
+      stopped = true
     case y if stopped => println("Received data when stopped " + this.getClass.getSimpleName + " of type " + y.getClass )
   }
 

--- a/ts/src/main/scala/ch/epfl/ts/component/fetch/HistDataCSVFetcher.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/fetch/HistDataCSVFetcher.scala
@@ -100,7 +100,7 @@ class HistDataCSVFetcher(dataDir: String, currencyPair: String,
       if (allQuotes.hasNext) {
         // If there is a next quote, schedule the next call
         currentQuote = nextQuote
-        nextQuote = allQuotes.next
+        nextQuote = allQuotes.next //TODO(sygi): changing speed doesn't make too much sense, when all quotes have the same timestamp
         timer.schedule(new SendQuotes(), (1 / speed * (nextQuote.timestamp - currentQuote.timestamp)).toInt)
       } else {
         // Nothing more to do here, boys!
@@ -193,7 +193,10 @@ class HistDataCSVFetcher(dataDir: String, currencyPair: String,
         Quote(q.marketId, q.timestamp, whatC, withC, q.bid, q.ask)
       })
   }
-  
+
+  override def stop = {
+    timer.cancel()
+  }
 }
 
 /**

--- a/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
@@ -19,16 +19,10 @@ class BackLoop(marketId: Long, p: Persistance[Transaction]) extends Component {
     case t: Transaction => {
       send(t)
       p.save(t)
-      send(createQuote(t))
     }
     case la: LimitAskOrder => send(la)
     case lb: LimitBidOrder => send(lb)
     case d: DelOrder => send(d)
     case _ => println("Looper: received unknown")
-  }
-
-  def createQuote(t: Transaction){
-    return Quote(t.mid, t.timestamp, t.whatC, t.withC, t.price, t.price)
-    //TODO(sygi): to implement it properly, we need working MarketSimulator (the one that keeps orderbooks)
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
@@ -2,7 +2,12 @@ package ch.epfl.ts.component.utils
 
 import ch.epfl.ts.component.Component
 import ch.epfl.ts.component.persist.Persistance
-import ch.epfl.ts.data.{DelOrder, LimitAskOrder, LimitBidOrder, Transaction}
+import ch.epfl.ts.data._
+import ch.epfl.ts.data.Currency._
+import ch.epfl.ts.data.Transaction
+import ch.epfl.ts.data.LimitBidOrder
+import ch.epfl.ts.data.DelOrder
+import ch.epfl.ts.data.LimitAskOrder
 
 /**
  * Backloop component, plugged as Market Simulator's output. Saves the transactions in a persistor.
@@ -14,10 +19,16 @@ class BackLoop(marketId: Long, p: Persistance[Transaction]) extends Component {
     case t: Transaction => {
       send(t)
       p.save(t)
+      send(createQuote(t))
     }
     case la: LimitAskOrder => send(la)
     case lb: LimitBidOrder => send(lb)
     case d: DelOrder => send(d)
     case _ => println("Looper: received unknown")
+  }
+
+  def createQuote(t: Transaction){
+    return Quote(t.mid, t.timestamp, t.whatC, t.withC, t.price, t.price)
+    //TODO(sygi): to implement it properly, we need working MarketSimulator (the one that keeps orderbooks)
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/utils/BackLoop.scala
@@ -20,7 +20,7 @@ class BackLoop(marketId: Long, p: Persistance[Transaction]) extends Component {
       send(t)
       p.save(t)
     }
-    case la: LimitAskOrder => send(la)
+    case la: LimitAskOrder => send(la) //WhereTF is this being used?
     case lb: LimitBidOrder => send(lb)
     case d: DelOrder => send(d)
     case _ => println("Looper: received unknown")

--- a/ts/src/main/scala/ch/epfl/ts/component/utils/Timekeeper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/utils/Timekeeper.scala
@@ -1,0 +1,46 @@
+package ch.epfl.ts.component.utils
+
+import akka.actor.Actor
+import scala.concurrent.duration.FiniteDuration
+import ch.epfl.ts.component.StopSignal
+import java.util.Timer
+import ch.epfl.ts.data.TheTimeIs
+import akka.actor.ActorRef
+
+/**
+ * When switching from Replay to "full simulation" mode, historical data
+ * had timestamps from the past; and then suddenly our simulation must take
+ * charge of generating quotes. These new quotes emitted from the simulation
+ * can't just jump immediately to the present time. We thus introduce this component
+ * to bridge the time gap.
+ *  
+ * We use the last known time from historical data and add real physical time elapsed from
+ * here. Note that physical time will always elapse at 1x speed.
+ *  
+ * This component is instantiated with a fixed beginning date (timestamp) and will then emit
+ * periodically `TheTimeIs` messages.
+ * 
+ * @param parent The actor to send `TheTimeIs` messages
+ * @param timeBase Timestamp (milliseconds) from which to start 
+ * @param period Delay between two `TimeIsNow` messages.
+ *               Note this also defines the granularity of time in the system.
+ */
+class Timekeeper(val parent: ActorRef, val timeBase: Long, val period: FiniteDuration) extends Actor {
+
+  private val timeOffset: Long = System.currentTimeMillis()
+  
+  private val timer = new Timer()
+  private class SendTheTime extends java.util.TimerTask {
+    def run() {
+      // TODO: who to send it to?
+      val current = timeBase + (System.currentTimeMillis() - timeOffset)
+      parent ! TheTimeIs(current)
+    }
+  }
+  timer.scheduleAtFixedRate(new SendTheTime, 0L, period.toMillis)
+  
+  def receive = {
+    case _ => 
+  }
+  
+}

--- a/ts/src/main/scala/ch/epfl/ts/component/utils/Timekeeper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/component/utils/Timekeeper.scala
@@ -25,22 +25,20 @@ import akka.actor.ActorRef
  * @param period Delay between two `TimeIsNow` messages.
  *               Note this also defines the granularity of time in the system.
  */
+// TODO: replace the `parent` argument by simply using `context.parent`?
 class Timekeeper(val parent: ActorRef, val timeBase: Long, val period: FiniteDuration) extends Actor {
-
+  
   private val timeOffset: Long = System.currentTimeMillis()
   
   private val timer = new Timer()
   private class SendTheTime extends java.util.TimerTask {
     def run() {
-      // TODO: who to send it to?
       val current = timeBase + (System.currentTimeMillis() - timeOffset)
       parent ! TheTimeIs(current)
     }
   }
   timer.scheduleAtFixedRate(new SendTheTime, 0L, period.toMillis)
   
-  def receive = {
-    case _ => 
-  }
+  def receive = PartialFunction.empty
   
 }

--- a/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
+++ b/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
@@ -18,30 +18,30 @@ package ch.epfl.ts.config
  */
 
 trait FundDistribution {
-  def bins : List[Int];
-  val rand = new java.util.Random();
+  def bins : List[Int]
+  val rand = new java.util.Random()
   
   def percentListToDistribution(binsInPercent: List[(Int, Double)]) : List[Int] = {
     
-    assert(Math.abs(binsInPercent.foldRight(0.0)((elem, acc) => elem._2 + acc) - 100.0) < 0.001);
+    assert(Math.abs(binsInPercent.foldRight(0.0)((elem, acc) => elem._2 + acc) - 100.0) < 0.001)
     
-    val minPercent = binsInPercent.minBy(_._2)._2;
-    val distribution = binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1));
+    val minPercent = binsInPercent.minBy(_._2)._2
+    val distribution = binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1))
     
     // add random high values for the entries of "more than xxx"
-    val highestAmount = binsInPercent.maxBy(_._1)._1;
+    val highestAmount = binsInPercent.maxBy(_._1)._1
     return distribution.map(x => {
       if (x == highestAmount) (x * (1.0 + rand.nextDouble())).toInt
       else x
-    });
+    })
     
     
   }
   
   def get: Int = {
-    val len = bins.length;
-    val idx = Math.floor(rand.nextDouble() * len).toInt;
-    bins(idx);
+    val len = bins.length
+    val idx = Math.floor(rand.nextDouble() * len).toInt
+    bins(idx)
   }
   
 }
@@ -68,9 +68,9 @@ class FundsGermany extends FundDistribution {
       (375000, 0.4),
       (500000, 0.2), // changed from 0.1 to 0.2 to add up to 100 %
       (1000000, 0.1),
-      (1000001, 0.1)); // people earning more than this
+      (1000001, 0.1)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -84,9 +84,9 @@ class FundsSwitzerland extends FundDistribution {
       (6000, 20.9),
       (7000, 12.9),
       (8000, 8.3),
-      (8001, 19.3)).map(x => (x._1 * 12, x._2)); // original data was given as monthly income
+      (8001, 19.3)).map(x => (x._1 * 12, x._2)) // original data was given as monthly income
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -114,9 +114,9 @@ class FundsUSA extends FundDistribution {
       (190000, 0.7),
       (200000, 0.5),
       (250000, 1.8),
-      (250001, 2.1)); // changed from 2.5 to 2.1 to add up to 100 %
+      (250001, 2.1)) // changed from 2.5 to 2.1 to add up to 100 %
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -143,9 +143,9 @@ class FundsJapan extends FundDistribution {
       (1800000, 0.3),
       (1900000, 0.2),
       (2000000, 0.2),
-      (2000001, 1.0)); // people earning more than this
+      (2000001, 1.0)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -161,9 +161,9 @@ class FundsRussia extends FundDistribution {
       (19000, 15.6),
       (27000, 15.9),
       (45000, 15.0),
-      (45001, 8.2)).map(x => (x._1 * 12, x._2)); // people earning more than this
+      (45001, 8.2)).map(x => (x._1 * 12, x._2)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -183,7 +183,7 @@ class FundsCanada extends FundDistribution {
 //      (100000, 1788000.0),
 //      (150000, 619050.0),
 //      (200000, 312930.0),
-//      (250000, 192250.0)); // people earning more than this
+//      (250000, 192250.0)) // people earning more than this
       (5000, 1932690),
       (10000, 1806110),
       (15000, 2346610),
@@ -196,9 +196,9 @@ class FundsCanada extends FundDistribution {
       (150000, 1168950),
       (200000, 306120),
       (250000, 120680),
-      (250001, 192250)).map(x => (x._1, x._2 * 100 / 25797510.0)); // people earning more than this
+      (250001, 192250)).map(x => (x._1, x._2 * 100 / 25797510.0)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -217,9 +217,9 @@ class FundsUK extends FundDistribution {
       (50000, 2.0),
       (60000, 2.0),
       (75000, 2.0),
-      (75001, 1.0)); // people earning more than this
+      (75001, 1.0)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }
 
@@ -238,8 +238,8 @@ class FundsAustralia extends FundDistribution {
       (1250, 7.9),
       (1500, 5.5),
       (2000, 6.4),
-      (2001, 6.2 + 7.8)).map(x => (x._1 * 52, x._2)); // people earning more than this
+      (2001, 6.2 + 7.8)).map(x => (x._1 * 52, x._2)) // people earning more than this
   
-  override def bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent)
   
 }

--- a/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
+++ b/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
@@ -1,0 +1,70 @@
+package ch.epfl.ts.config
+
+/**
+ * Local money distributions.
+ * Each country is implemented as a class that inherits from FundDistribution.
+ * Statistics are entered in tuples (amount in local currency, percentage of people earning this amount).
+ * Internally, a list of integers is created that contains as many entries of
+ * a particular amount as the percentage indicates.
+ * When calling "get" a sample out of the internal list is returned using a Random object.
+ */
+
+trait FundDistribution {
+  var bins : List[Int];
+  val rand = new java.util.Random();
+  
+  def percentListToDistribution(binsInPercent: List[(Int, Double)]) : List[Int] = {
+    val minPercent = binsInPercent.minBy(_._2)._2;
+    return binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1));
+  }
+  
+  def get: Int = {
+    val len = bins.length;
+    val idx = Math.floor(rand.nextDouble() * len).toInt;
+    bins(idx);
+  }
+  
+}
+
+class FundsGermany extends FundDistribution {
+  // from http://de.statista.com/statistik/daten/studie/202/umfrage/jahreseinkommen-einkommensteuerpflichtiger-2004/
+  val binsInPercent = List(
+      (2500, 3.2),
+      (5000, 2.2),
+      (7500, 2.7),
+      (10000, 3.7),
+      (12500, 4.9),
+      (15000, 4.9),
+      (20000, 9.4),
+      (25000, 9.4),
+      (30000, 9.2),
+      (37500, 11.9),
+      (50000, 13.9),
+      (75000, 13.8),
+      (100000, 5.4),
+      (125000, 2.2),
+      (175000, 1.6),
+      (250000, 0.8),
+      (375000, 0.4),
+      (500000, 0.1),
+      (1000000, 0.1),
+      (1000001, 0.1));
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsSwitzerland extends FundDistribution {
+  // from http://www.bfs.admin.ch/bfs/portal/en/index/themen/03/04/blank/key/lohnstruktur/lohnverteilung.html
+  val binsInPercent = List(
+      (3000, 2.3),
+      (4000, 12.6),
+      (5000, 23.7),
+      (6000, 20.9),
+      (7000, 12.9),
+      (8000, 8.3),
+      (8001, 19.3)).map(x => (x._1 * 12, x._2));
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}

--- a/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
+++ b/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
@@ -18,7 +18,7 @@ package ch.epfl.ts.config
  */
 
 trait FundDistribution {
-  var bins : List[Int];
+  def bins : List[Int];
   val rand = new java.util.Random();
   
   def percentListToDistribution(binsInPercent: List[(Int, Double)]) : List[Int] = {
@@ -26,7 +26,16 @@ trait FundDistribution {
     assert(Math.abs(binsInPercent.foldRight(0.0)((elem, acc) => elem._2 + acc) - 100.0) < 0.001);
     
     val minPercent = binsInPercent.minBy(_._2)._2;
-    return binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1));
+    val distribution = binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1));
+    
+    // add random high values for the entries of "more than xxx"
+    val highestAmount = binsInPercent.maxBy(_._1)._1;
+    return distribution.map(x => {
+      if (x == highestAmount) (x * (1.0 + rand.nextDouble())).toInt
+      else x
+    });
+    
+    
   }
   
   def get: Int = {
@@ -61,7 +70,7 @@ class FundsGermany extends FundDistribution {
       (1000000, 0.1),
       (1000001, 0.1)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -77,7 +86,7 @@ class FundsSwitzerland extends FundDistribution {
       (8000, 8.3),
       (8001, 19.3)).map(x => (x._1 * 12, x._2)); // original data was given as monthly income
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -107,7 +116,7 @@ class FundsUSA extends FundDistribution {
       (250000, 1.8),
       (250001, 2.1)); // changed from 2.5 to 2.1 to add up to 100 %
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -136,7 +145,7 @@ class FundsJapan extends FundDistribution {
       (2000000, 0.2),
       (2000001, 1.0)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -154,7 +163,7 @@ class FundsRussia extends FundDistribution {
       (45000, 15.0),
       (45001, 8.2)).map(x => (x._1 * 12, x._2)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -189,7 +198,7 @@ class FundsCanada extends FundDistribution {
       (250000, 120680),
       (250001, 192250)).map(x => (x._1, x._2 * 100 / 25797510.0)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -210,7 +219,7 @@ class FundsUK extends FundDistribution {
       (75000, 2.0),
       (75001, 1.0)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }
 
@@ -231,6 +240,6 @@ class FundsAustralia extends FundDistribution {
       (2000, 6.4),
       (2001, 6.2 + 7.8)).map(x => (x._1 * 52, x._2)); // people earning more than this
   
-  override var bins = percentListToDistribution(binsInPercent);
+  override def bins = percentListToDistribution(binsInPercent);
   
 }

--- a/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
+++ b/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
@@ -22,6 +22,9 @@ trait FundDistribution {
   val rand = new java.util.Random();
   
   def percentListToDistribution(binsInPercent: List[(Int, Double)]) : List[Int] = {
+    
+    assert(Math.abs(binsInPercent.foldRight(0.0)((elem, acc) => elem._2 + acc) - 100.0) < 0.001);
+    
     val minPercent = binsInPercent.minBy(_._2)._2;
     return binsInPercent.flatMap(x => List.fill(Math.round(x._2 / minPercent).toInt)(x._1));
   }
@@ -54,7 +57,7 @@ class FundsGermany extends FundDistribution {
       (175000, 1.6),
       (250000, 0.8),
       (375000, 0.4),
-      (500000, 0.1),
+      (500000, 0.2), // changed from 0.1 to 0.2 to add up to 100 %
       (1000000, 0.1),
       (1000001, 0.1)); // people earning more than this
   
@@ -64,6 +67,7 @@ class FundsGermany extends FundDistribution {
 
 class FundsSwitzerland extends FundDistribution {
   // from http://www.bfs.admin.ch/bfs/portal/en/index/themen/03/04/blank/key/lohnstruktur/lohnverteilung.html
+  // - data were given as weekly income (have to multiply by 12)
   val binsInPercent = List(
       (3000, 2.3),
       (4000, 12.6),
@@ -101,7 +105,7 @@ class FundsUSA extends FundDistribution {
       (190000, 0.7),
       (200000, 0.5),
       (250000, 1.8),
-      (250001, 2.5)); // people earning more than this
+      (250001, 2.1)); // changed from 2.5 to 2.1 to add up to 100 %
   
   override var bins = percentListToDistribution(binsInPercent);
   
@@ -139,7 +143,7 @@ class FundsJapan extends FundDistribution {
 class FundsRussia extends FundDistribution {
   // from http://www.gks.ru/bgd/regl/b12_110/Main.htm (first blue arrow, first file)
   // alternatively in USD http://www.forbes.com/sites/markadomanis/2012/09/10/what-is-the-russian-middle-class-probably-not-what-you-think/
-  // data were given as monthly income
+  // - data were given as monthly income (have to multiply by 12)
   val binsInPercent = List(
       (5000, 7.3),
       (7000, 8.2),
@@ -156,7 +160,7 @@ class FundsRussia extends FundDistribution {
 
 class FundsCanada extends FundDistribution {
   // from http://www.statcan.gc.ca/tables-tableaux/sum-som/l01/cst01/famil105a-eng.htm
-  // source data was given in the form "total of xxx and over, number of people" and converted accordingly
+  // source data were given in the form "total of xxx and over, number of people" and converted accordingly
   val binsInPercent = List(
 //      (0, 1932690.0),
 //      (5000, 23864820.0),
@@ -183,7 +187,7 @@ class FundsCanada extends FundDistribution {
       (150000, 1168950),
       (200000, 306120),
       (250000, 120680),
-      (250001, 192250)).map(x => (x._1, x._2 / 25797510.0)); // people earning more than this
+      (250001, 192250)).map(x => (x._1, x._2 * 100 / 25797510.0)); // people earning more than this
   
   override var bins = percentListToDistribution(binsInPercent);
   
@@ -212,7 +216,7 @@ class FundsUK extends FundDistribution {
 
 class FundsAustralia extends FundDistribution {
   // from http://profile.id.com.au/australia/individual-income
-  // data were given as weekly income
+  // - data were given as weekly income (have to multiply by 52)
   // - negative/NIL income was added to the lowest income bin
   // - not stated was added to the highest income bin
   val binsInPercent = List(
@@ -225,7 +229,7 @@ class FundsAustralia extends FundDistribution {
       (1250, 7.9),
       (1500, 5.5),
       (2000, 6.4),
-      (2001, 6.2 + 7.9)).map(x => (x._1 * 52, x._2)); // people earning more than this
+      (2001, 6.2 + 7.8)).map(x => (x._1 * 52, x._2)); // people earning more than this
   
   override var bins = percentListToDistribution(binsInPercent);
   

--- a/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
+++ b/ts/src/main/scala/ch/epfl/ts/config/FundDistribution.scala
@@ -3,9 +3,17 @@ package ch.epfl.ts.config
 /**
  * Local money distributions.
  * Each country is implemented as a class that inherits from FundDistribution.
- * Statistics are entered in tuples (amount in local currency, percentage of people earning this amount).
+ * Statistics are entered in tuples:
+ * _1 : amount in local currency (upper boundary of bins in statistics)
+ * _2 : percentage of people earning this amount 
+ *
  * Internally, a list of integers is created that contains as many entries of
  * a particular amount as the percentage indicates.
+ *
+ * The last entry of the list has no upper bound i.e. it indicates how many people
+ * earn MORE than this amount. The sampled earnings can therefore be replaced with 
+ * any amount larger than indicated here/ 
+ *
  * When calling "get" a sample out of the internal list is returned using a Random object.
  */
 
@@ -48,7 +56,7 @@ class FundsGermany extends FundDistribution {
       (375000, 0.4),
       (500000, 0.1),
       (1000000, 0.1),
-      (1000001, 0.1));
+      (1000001, 0.1)); // people earning more than this
   
   override var bins = percentListToDistribution(binsInPercent);
   
@@ -63,7 +71,161 @@ class FundsSwitzerland extends FundDistribution {
       (6000, 20.9),
       (7000, 12.9),
       (8000, 8.3),
-      (8001, 19.3)).map(x => (x._1 * 12, x._2));
+      (8001, 19.3)).map(x => (x._1 * 12, x._2)); // original data was given as monthly income
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsUSA extends FundDistribution {
+  // from https://introductorystats.wordpress.com
+  val binsInPercent = List(
+      (10000, 7.8),
+      (20000, 12.1),
+      (30000, 11.5),
+      (40000, 10.2),
+      (50000, 8.9),
+      (60000, 7.8),
+      (70000, 6.7),
+      (80000, 5.8),
+      (90000, 4.9),
+      (100000, 3.9),
+      (110000, 3.6),
+      (120000, 2.7),
+      (130000, 2.3),
+      (140000, 1.9),
+      (150000, 1.5),
+      (160000, 1.4),
+      (170000, 1.0),
+      (180000, 0.9),
+      (190000, 0.7),
+      (200000, 0.5),
+      (250000, 1.8),
+      (250001, 2.5)); // people earning more than this
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsJapan extends FundDistribution {
+  // from http://nbakki.hatenablog.com/entry/2014/07/17/184742
+  val binsInPercent = List(
+      (100000, 6.2),
+      (200000, 13.2),
+      (300000, 13.3),
+      (400000, 13.2),
+      (500000, 11.0),
+      (600000, 9.0),
+      (700000, 7.3),
+      (800000, 6.5),
+      (900000, 5.2),
+      (1000000, 3.8),
+      (1100000, 3.0),
+      (1200000, 2.0),
+      (1300000, 1.5),
+      (1400000, 1.1),
+      (1500000, 0.9),
+      (1600000, 0.6),
+      (1700000, 0.5),
+      (1800000, 0.3),
+      (1900000, 0.2),
+      (2000000, 0.2),
+      (2000001, 1.0)); // people earning more than this
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsRussia extends FundDistribution {
+  // from http://www.gks.ru/bgd/regl/b12_110/Main.htm (first blue arrow, first file)
+  // alternatively in USD http://www.forbes.com/sites/markadomanis/2012/09/10/what-is-the-russian-middle-class-probably-not-what-you-think/
+  // data were given as monthly income
+  val binsInPercent = List(
+      (5000, 7.3),
+      (7000, 8.2),
+      (10000, 13.5),
+      (14000, 16.3),
+      (19000, 15.6),
+      (27000, 15.9),
+      (45000, 15.0),
+      (45001, 8.2)).map(x => (x._1 * 12, x._2)); // people earning more than this
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsCanada extends FundDistribution {
+  // from http://www.statcan.gc.ca/tables-tableaux/sum-som/l01/cst01/famil105a-eng.htm
+  // source data was given in the form "total of xxx and over, number of people" and converted accordingly
+  val binsInPercent = List(
+//      (0, 1932690.0),
+//      (5000, 23864820.0),
+//      (10000, 22058710.0),
+//      (15000, 19712100.0),
+//      (20000, 17173030.0),
+//      (25000, 15058920.0),
+//      (35000, 11733230.0),
+//      (50000, 7597110.0),
+//      (75000, 3681450.0),
+//      (100000, 1788000.0),
+//      (150000, 619050.0),
+//      (200000, 312930.0),
+//      (250000, 192250.0)); // people earning more than this
+      (5000, 1932690),
+      (10000, 1806110),
+      (15000, 2346610),
+      (20000, 2539070),
+      (25000, 2114110),
+      (35000, 3325690),
+      (50000, 4136120),
+      (75000, 3915660),
+      (100000, 1893450),
+      (150000, 1168950),
+      (200000, 306120),
+      (250000, 120680),
+      (250001, 192250)).map(x => (x._1, x._2 / 25797510.0)); // people earning more than this
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsUK extends FundDistribution {
+  // from http://en.wikipedia.org/wiki/Income_in_the_United_Kingdom
+  val binsInPercent = List(
+      (5000, 3.0),
+      (10000, 7.0),
+      (15000, 21.0),
+      (20000, 19.0),
+      (25000, 16.0),
+      (30000, 11.0),
+      (35000, 8.0),
+      (40000, 5.0),
+      (45000, 3.0),
+      (50000, 2.0),
+      (60000, 2.0),
+      (75000, 2.0),
+      (75001, 1.0)); // people earning more than this
+  
+  override var bins = percentListToDistribution(binsInPercent);
+  
+}
+
+class FundsAustralia extends FundDistribution {
+  // from http://profile.id.com.au/australia/individual-income
+  // data were given as weekly income
+  // - negative/NIL income was added to the lowest income bin
+  // - not stated was added to the highest income bin
+  val binsInPercent = List(
+      (200, 7.4 + 8.2),
+      (300, 10.4),
+      (400, 9.9),
+      (600, 11.6),
+      (800, 10.4),
+      (1000, 8.3),
+      (1250, 7.9),
+      (1500, 5.5),
+      (2000, 6.4),
+      (2001, 6.2 + 7.9)).map(x => (x._1 * 52, x._2)); // people earning more than this
   
   override var bins = percentListToDistribution(binsInPercent);
   

--- a/ts/src/main/scala/ch/epfl/ts/data/Messages.scala
+++ b/ts/src/main/scala/ch/epfl/ts/data/Messages.scala
@@ -6,6 +6,13 @@ import ch.epfl.ts.data.Currency._
  * Definition of the System's internal messages.
  */
 trait Streamable
+ 
+/**
+ * Message sent out by an actor which takes authority on the system's time.
+ * This way, we may override both physical time and historical data time if needed.
+ * @see Timekeeper
+ */
+case class TheTimeIs(now: Long) extends Streamable
 
 /**
  * Data Transfer Object representing a Transaction

--- a/ts/src/main/scala/ch/epfl/ts/data/Messages.scala
+++ b/ts/src/main/scala/ch/epfl/ts/data/Messages.scala
@@ -92,6 +92,7 @@ case class LimitAskOrder(val oid: Long, val uid: Long, val timestamp: Long, val 
   extends LimitOrder {
   override def costCurrency() = whatC
 }
+//TODO: remove price from common subclass, as for MarketOrders it doesn't make sense
 abstract class MarketOrder extends Order
 
 /**
@@ -144,7 +145,7 @@ case class OHLC(marketId: Long, open: Double, high: Double, low: Double, close: 
  *
  * @see LimitOrder
  */
-case class Quote(marketId: Long, timestamp: Long, whatC: Currency, withC: Currency, bid: Double, ask: Double) {
+case class Quote(marketId: Long, timestamp: Long, whatC: Currency, withC: Currency, bid: Double, ask: Double) extends Streamable {
   override def toString() = "(" + whatC.toString().toUpperCase() + "/" + withC.toString().toUpperCase() + ") = (" + bid + ", " + ask + ")";
 }
 

--- a/ts/src/main/scala/ch/epfl/ts/engine/HybridMarketSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/HybridMarketSimulator.scala
@@ -24,12 +24,13 @@ class HybridMarketSimulator(marketId: Long, rules1: FxMarketRulesWrapper, rules2
     case 'ChangeMarketRules =>
       log.info("Hybrid market: changing rules")
       changeRules
-    case q: Quote =>
-      log.debug("Hybrid market: got quote: " + q)
+    case q: Quote if (!isSimulating) =>
+      rules1.checkPendingOrders(marketId, book, tradingPrices, this.send[Streamable])
+      log.debug("HybridMarket: got quote: " + q)
       tradingPrices((q.withC, q.whatC)) = (q.bid, q.ask)
-      if (!isSimulating)
-        rules1.checkPendingOrders(marketId, book, tradingPrices, this.send[Streamable])
       send(q)
+    case q: Quote if (isSimulating) =>
+      log.warning("HybridMarket received a quote when in simulation mode")
   }
 
   def getCurrentRules = {

--- a/ts/src/main/scala/ch/epfl/ts/engine/HybridMarketSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/HybridMarketSimulator.scala
@@ -1,0 +1,38 @@
+package ch.epfl.ts.engine
+
+import ch.epfl.ts.data.{Quote, Order, Streamable}
+import ch.epfl.ts.engine.rules.{FxMarketRulesWrapper, MarketRulesWrapper}
+
+/**
+ * Market simulator, where first the data is being received from fetcher and market behaves in a way that traders' orders
+ * don't influence the prices (quotes) and after some time it changes to the regular market simulation,
+ * where traders buy/sell only among them.
+ * Rules should have same bids/asks ordering.
+ * Works only for one currency pair.
+ * Created by sygi on 09.05.15.
+ */
+class HybridMarketSimulator(marketId: Long, rules1: FxMarketRulesWrapper, rules2: MarketRulesWrapper) extends MarketSimulator(marketId, rules1.getRules) {
+  var rulesChanged = false
+  override def receiver: PartialFunction[Any, Unit] = {
+    case o: Order =>
+      getCurrentRules.processOrder(o, marketId, book, tradingPrices, this.send[Streamable])
+    case 'ChangeMarketRules =>
+      println("Hybrid market: changing rules")
+      changeRules
+    case q: Quote =>
+      println("Hybrid market: got quote: " + q)
+      tradingPrices((q.withC, q.whatC)) = (q.bid, q.ask)
+      if (!rulesChanged)
+        rules1.checkPendingOrders(marketId, book, tradingPrices, this.send[Streamable])
+      send(q)
+  }
+
+  def getCurrentRules = {
+    if (rulesChanged)
+      rules2
+    else
+      rules1
+  }
+  def changeRules =
+    rulesChanged = !rulesChanged
+}

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
@@ -1,43 +1,26 @@
 package ch.epfl.ts.engine
 
-import ch.epfl.ts.data.LimitAskOrder
-import ch.epfl.ts.data.LimitBidOrder
-import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.data._
+import akka.actor.ActorLogging
 import ch.epfl.ts.data.MarketBidOrder
 import ch.epfl.ts.data.Quote
-import ch.epfl.ts.data.Streamable
-import akka.actor.ActorLogging
+import ch.epfl.ts.data.LimitBidOrder
+import scala.Some
+import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.data.LimitAskOrder
+import ch.epfl.ts.engine.rules.FxMarketRulesWrapper
 
-class MarketFXSimulator(marketId: Long, rules: ForexMarketRules) extends MarketSimulator(marketId, rules) with ActorLogging {
-
+class MarketFXSimulator(marketId: Long, val rulesWrapper: FxMarketRulesWrapper = new FxMarketRulesWrapper())
+    extends MarketSimulator(marketId, rulesWrapper.rules) with ActorLogging {
   override def receiver = {
-    case limitBid: LimitBidOrder =>
-    // TODO
-
-    case limitAsk: LimitAskOrder =>
-    // TODO - add limit order resolvation based on given quotes
-
-    case marketBid: MarketBidOrder =>
-      log.debug("MarketFXSimulator : received a bidOrder")
-      tradingPrices.get((marketBid.whatC, marketBid.withC)) match {
-        // We buy at current ask price
-        case Some(t) => rules.matchingFunction(marketId, marketBid, book.bids, book.asks, this.send[Streamable], t._2)
-        case None    => // TODO: throw an error of some kind
-      }
-    case marketAsk: MarketAskOrder =>
-      log.debug("MarketFXSimulator : received an askOrder")
-      tradingPrices.get((marketAsk.whatC, marketAsk.withC)) match {
-        // We sell at current bid price
-        case Some(t) => rules.matchingFunction(marketId, marketAsk, book.bids, book.asks, this.send[Streamable], t._1)
-          //TODO(sygi): does it actually work at all, when there are multiple currencies?
-        case None    => // TODO: throw an error of some kind
-      }
+    case o: Order =>
+      rulesWrapper.processOrder(o, marketId, book, tradingPrices, this.send[Streamable])
     case q: Quote =>
-      println("MS: got quote: " + q)
-      tradingPrices((q.whatC, q.withC)) = (q.bid, q.ask)
+      log.debug("FxMS: got quote: " + q)
+      tradingPrices((q.withC, q.whatC)) = (q.bid, q.ask)
+      rulesWrapper.checkPendingOrders(marketId, book, tradingPrices, this.send[Streamable])
       send(q)
-
     case _ =>
-      println("MS: got unknown")
+      println("FxMS: got unknown")
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
@@ -15,7 +15,7 @@ class MarketFXSimulator(marketId: Long, rules: ForexMarketRules) extends MarketS
     // TODO
 
     case limitAsk: LimitAskOrder =>
-    // TODO
+    // TODO - add limit order resolvation based on given quotes
 
     case marketBid: MarketBidOrder =>
       log.debug("MarketFXSimulator : received a bidOrder")
@@ -29,12 +29,13 @@ class MarketFXSimulator(marketId: Long, rules: ForexMarketRules) extends MarketS
       tradingPrices.get((marketAsk.whatC, marketAsk.withC)) match {
         // We sell at current bid price
         case Some(t) => rules.matchingFunction(marketId, marketAsk, book.bids, book.asks, this.send[Streamable], t._1)
+          //TODO(sygi): does it actually work at all, when there are multiple currencies?
         case None    => // TODO: throw an error of some kind
       }
-    //TODO Forward quote (just uncomment) , and disconnect all other components that are connected to the fetcher : use marketFXSimulator instead as quote provider.
     case q: Quote =>
-      //send(q)
+      println("MS: got quote: " + q)
       tradingPrices((q.whatC, q.withC)) = (q.bid, q.ask)
+      send(q)
 
     case _ =>
       println("MS: got unknown")

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketFXSimulator.scala
@@ -16,10 +16,10 @@ class MarketFXSimulator(marketId: Long, val rulesWrapper: FxMarketRulesWrapper =
     case o: Order =>
       rulesWrapper.processOrder(o, marketId, book, tradingPrices, this.send[Streamable])
     case q: Quote =>
+      send(q)
       log.debug("FxMS: got quote: " + q)
       tradingPrices((q.withC, q.whatC)) = (q.bid, q.ask)
       rulesWrapper.checkPendingOrders(marketId, book, tradingPrices, this.send[Streamable])
-      send(q)
     case _ =>
       println("FxMS: got unknown")
   }

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
@@ -7,7 +7,6 @@ import ch.epfl.ts.data.MarketBidOrder
 import ch.epfl.ts.data.Transaction
 import ch.epfl.ts.data.DelOrder
 import ch.epfl.ts.data.LimitBidOrder
-import ch.epfl.ts.engine.Commission
 import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.data.LimitAskOrder
 
@@ -134,8 +133,9 @@ class MarketRules extends Serializable {
     if (!bids.isEmpty && !asks.isEmpty){
       val topBid = bids.head
       val topAsk = asks.head
+      println("MR: generating quote " + topBid.price + " " + topAsk.price)
       send(Quote(marketId, timestamp, topAsk.whatC, topAsk.withC, topBid.price, topAsk.price))
-    }
-
+    } else
+      println("MR: can't generate quote")
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
@@ -11,7 +11,7 @@ import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.data.LimitAskOrder
 
 /**
- * represents the cost of placing a bid and market order
+ * Represents the cost of placing a bid and market order
  */
 case class Commission(limitOrderFee: Double, marketOrderFee: Double)
 
@@ -45,28 +45,42 @@ class MarketRules extends Serializable {
 
   def alwaysTrue(a: Double, b: Double) = true
 
+  /**
+   * It tries to match the new order with the orders in the PartialOrderBooks and generates new Quotes for the market.
+   * @param marketId
+   * @param newOrder the order you want to process right now
+   * @param newOrdersBook the partial order book of the orders of the same type (bid or ask) as the newOrder
+   * @param bestMatchesBook the partial order book of the orders of the opposite type (ask or bid)
+   * @param send a belonging to the Actor function that is going to be executed with executed Order (if there is one)
+   *             and other Messages that are going to be sent to the other Actors
+   * @param matchExists the actual matching function (checks if the order should be executed right now) between the newOrder
+   *                    and the top entry in bestMatchesBook
+   * @param oldTradingPrice previous market price of the same type (bid/ask) as the newOrder
+   * @param enqueueOrElse the function that basically does: "newOrdersBook insert newOrder" - it enqueues the newOrder.
+   *                      It gets executed only when there's no match for the order.
+   * @return the price of last executed order (possibly this one) of newOrder type (bid/ask) (no change if there was no match)
+   */
   def matchingFunction(marketId: Long,
                        newOrder: Order,
                        newOrdersBook: PartialOrderBook,
-                       bestMatchsBook: PartialOrderBook,
+                       bestMatchesBook: PartialOrderBook,
                        send: Streamable => Unit,
                        matchExists: (Double, Double) => Boolean = alwaysTrue,
                        oldTradingPrice: Double,
                        enqueueOrElse: (Order, PartialOrderBook) => Unit): Double = {
     var result = -1.0
-    println("MS: got new order: " + newOrder)
 
-    if (bestMatchsBook.isEmpty) {
+    if (bestMatchesBook.isEmpty) {
       println("MS: matching orders book empty")
       enqueueOrElse(newOrder, newOrdersBook)
       result = oldTradingPrice
     } else {
 
-      val bestMatch = bestMatchsBook.head
+      val bestMatch = bestMatchesBook.head
       // check if a matching order exists when used with a limit order, if market order: matchExists = true
       if (matchExists(bestMatch.price, newOrder.price)) {
 
-        bestMatchsBook delete bestMatch
+        bestMatchesBook delete bestMatch
         send(DelOrder(bestMatch.oid, bestMatch.uid, newOrder.timestamp, DEF, DEF, 0.0, 0.0))
 
         // perfect match
@@ -86,11 +100,11 @@ class MarketRules extends Serializable {
           println("MS: removing order: " + bestMatch + " from match orders book. enqueuing same order with " + (bestMatch.volume - newOrder.volume) + " volume.")
           bestMatch match {
             case lbo: LimitBidOrder =>
-              bestMatchsBook insert LimitBidOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price)
+              bestMatchesBook insert LimitBidOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price)
               send(Transaction(marketId, bestMatch.price, newOrder.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.uid, bestMatch.oid, newOrder.uid, newOrder.oid))
               send(LimitBidOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price))
             case lao: LimitAskOrder =>
-              bestMatchsBook insert LimitAskOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price)
+              bestMatchesBook insert LimitAskOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price)
               send(Transaction(marketId, bestMatch.price, newOrder.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, newOrder.uid, newOrder.oid, bestMatch.uid, bestMatch.oid))
               send(LimitAskOrder(bestMatch.oid, bestMatch.uid, bestMatch.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.volume - newOrder.volume, bestMatch.price))
             case _ => println("MarketRules: casting error")
@@ -102,16 +116,16 @@ class MarketRules extends Serializable {
           bestMatch match {
             case lbo: LimitBidOrder =>
               send(Transaction(marketId, bestMatch.price, bestMatch.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, newOrder.uid, newOrder.oid, bestMatch.uid, bestMatch.oid))
-              matchingFunction(marketId, LimitBidOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, bestMatch.price), newOrdersBook, bestMatchsBook, send, matchExists, oldTradingPrice, enqueueOrElse)
+              matchingFunction(marketId, LimitBidOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, bestMatch.price), newOrdersBook, bestMatchesBook, send, matchExists, oldTradingPrice, enqueueOrElse)
             case lao: LimitAskOrder =>
               send(Transaction(marketId, bestMatch.price, bestMatch.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.uid, bestMatch.oid, newOrder.uid, newOrder.oid))
-              matchingFunction(marketId, LimitAskOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, bestMatch.price), newOrdersBook, bestMatchsBook, send, matchExists, oldTradingPrice, enqueueOrElse)
+              matchingFunction(marketId, LimitAskOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, bestMatch.price), newOrdersBook, bestMatchesBook, send, matchExists, oldTradingPrice, enqueueOrElse)
             case mbo: MarketBidOrder =>
               send(Transaction(marketId, bestMatch.price, bestMatch.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, newOrder.uid, newOrder.oid, bestMatch.uid, bestMatch.oid))
-              matchingFunction(marketId, MarketBidOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, newOrder.price), newOrdersBook, bestMatchsBook, send, matchExists, oldTradingPrice, enqueueOrElse)
+              matchingFunction(marketId, MarketBidOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, newOrder.price), newOrdersBook, bestMatchesBook, send, matchExists, oldTradingPrice, enqueueOrElse)
             case mao: MarketAskOrder =>
               send(Transaction(marketId, bestMatch.price, bestMatch.volume, newOrder.timestamp, bestMatch.whatC, bestMatch.withC, bestMatch.uid, bestMatch.oid, newOrder.uid, newOrder.oid))
-              matchingFunction(marketId, MarketAskOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, newOrder.price), newOrdersBook, bestMatchsBook, send, matchExists, oldTradingPrice, enqueueOrElse)
+              matchingFunction(marketId, MarketAskOrder(newOrder.oid, newOrder.uid, newOrder.timestamp, newOrder.whatC, newOrder.withC, newOrder.volume - bestMatch.volume, newOrder.price), newOrdersBook, bestMatchesBook, send, matchExists, oldTradingPrice, enqueueOrElse)
             case _ => println("MarketRules: casting error")
           }
         }
@@ -126,9 +140,11 @@ class MarketRules extends Serializable {
         result = oldTradingPrice
       }
     }
-    generateQuote(marketId, newOrdersBook, bestMatchsBook, newOrder.timestamp, send)
+    generateQuote(marketId, newOrdersBook, bestMatchesBook, newOrder.timestamp, send)
     result
   }
+
+  //ob1 and ob2 contains the two partial orderbooks: asks and bids, but we don't know which is which.
   def generateQuote(marketId: Long, ob1: PartialOrderBook, ob2: PartialOrderBook, timestamp: Long, send: Streamable => Unit) = {
     if (!ob1.isEmpty && !ob2.isEmpty){
       var topAsk = ob1.head

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
@@ -129,10 +129,15 @@ class MarketRules extends Serializable {
     generateQuote(marketId, newOrdersBook, bestMatchsBook, newOrder.timestamp, send)
     result
   }
-  def generateQuote(marketId: Long, bids: PartialOrderBook, asks: PartialOrderBook, timestamp: Long, send: Streamable => Unit) = {
-    if (!bids.isEmpty && !asks.isEmpty){
-      val topBid = bids.head
-      val topAsk = asks.head
+  def generateQuote(marketId: Long, ob1: PartialOrderBook, ob2: PartialOrderBook, timestamp: Long, send: Streamable => Unit) = {
+    if (!ob1.isEmpty && !ob2.isEmpty){
+      var topAsk = ob1.head
+      var topBid = ob2.head
+      if (topAsk.price < topBid.price){
+        val tmp = topAsk
+        topAsk = topBid
+        topBid = tmp
+      }
       println("MR: generating quote " + topBid.price + " " + topAsk.price)
       send(Quote(marketId, timestamp, topAsk.whatC, topAsk.withC, topBid.price, topAsk.price))
     } else

--- a/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/MarketRules.scala
@@ -154,8 +154,9 @@ class MarketRules extends Serializable {
         topAsk = topBid
         topBid = tmp
       }
-      println("MR: generating quote " + topBid.price + " " + topAsk.price)
-      send(Quote(marketId, timestamp, topAsk.whatC, topAsk.withC, topBid.price, topAsk.price))
+      val q = Quote(marketId, timestamp, topAsk.whatC, topAsk.withC, topBid.price, topAsk.price)
+      println("MR: generating quote " + q)
+      send(q)
     } else
       println("MR: can't generate quote")
   }

--- a/ts/src/main/scala/ch/epfl/ts/engine/Messages.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/Messages.scala
@@ -39,7 +39,6 @@ object ExecutedBidOrder {
 object ExecutedAskOrder {
   def apply(o: Order,price:Double): ExecutedAskOrder = ExecutedAskOrder(o.oid, o.uid, o.timestamp, o.whatC, o.withC, o.volume, price)
 }
-//TODO(sygi): change this messages and actually use them to communicate broker -> trader
 
 
 /* *****************************

--- a/ts/src/main/scala/ch/epfl/ts/engine/OrderBook.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/OrderBook.scala
@@ -3,6 +3,7 @@ package ch.epfl.ts.engine
 import ch.epfl.ts.data.Order
 
 import scala.collection.mutable.{HashMap => MHashMap, TreeSet => MTreeSet}
+import scala.collection.mutable
 
 /**
  * Container for the Order Book
@@ -37,6 +38,14 @@ class PartialOrderBook(val comparator: Ordering[Order]) {
   def head = book.head
 
   def size = book.size
+
+  override def toString :String = {
+    val sb = new mutable.StringBuilder
+    for(i <- book){
+      sb.append(i.toString + "\n")
+    }
+    sb.toString()
+  }
 }
 
 class OrderBook(val bids: PartialOrderBook, val asks: PartialOrderBook) {

--- a/ts/src/main/scala/ch/epfl/ts/engine/OrderBook.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/OrderBook.scala
@@ -6,7 +6,8 @@ import scala.collection.mutable.{HashMap => MHashMap, TreeSet => MTreeSet}
 import scala.collection.mutable
 
 /**
- * Container for the Order Book
+ * Container for the Order Book.
+ * It contains the ordered set of pending Order for one symbol, for either bid or ask.
  * The implementation has a HashMap with the orderIds matching the orders
  * because the naive implementation that required to execute a find() with
  * a predicate on the TreeSet to acquire the Order reference was executed 
@@ -26,7 +27,7 @@ class PartialOrderBook(val comparator: Ordering[Order]) {
   }
 
   /**
-   * insert order in book
+   * insert order in book.
    */
   def insert(o: Order): Unit = {
     bookMap update(o.oid, o)

--- a/ts/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
@@ -70,6 +70,9 @@ class OrderBookMarketSimulator(marketId: Long, rules: MarketRules) extends Marke
       // TODO: how to know which currency of the two was bought? (Which to update, bid or ask price?)
       tradingPrices((t.withC, t.whatC)) = (???, ???)
 
+    case q: Quote =>
+      throw new UnsupportedOperationException("OrderBook MarketSimulator should never receive and handle quotes. It generates them by itself.")
+
     case PrintBooks =>
       // print shows heap order (binary tree)
       println("Ask Orders Book: " + book.bids)

--- a/ts/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/OrderBookMarketSimulator.scala
@@ -10,71 +10,71 @@ import ch.epfl.ts.data._
  */
 case object PrintBooks
 
-
+//TODO(sygi): this can (and should) be rewritten in terms of SimulationMarketRulesWrapper
 class OrderBookMarketSimulator(marketId: Long, rules: MarketRules) extends MarketSimulator(marketId, rules) {
   
   override def receiver = {
     case limitBid: LimitBidOrder =>
       val currentPrice = tradingPrices((limitBid.withC, limitBid.whatC))
       val newBidPrice = rules.matchingFunction(
-              marketId, limitBid, book.bids, book.asks,
-              this.send[Streamable],
-              (a, b) => a <= b, currentPrice._1,
-              (limitBid, bidOrdersBook) => {
-                bidOrdersBook insert limitBid;
-                send(limitBid);
-                println("MS: order enqueued")
-              })
+        marketId, limitBid, book.bids, book.asks,
+        this.send[Streamable],
+        (a, b) => a <= b, currentPrice._1,
+        (limitBid, bidOrdersBook) => {
+          bidOrdersBook insert limitBid
+          send(limitBid)
+          println("MS: order enqueued")
+        })
       tradingPrices((limitBid.withC, limitBid.whatC)) = (newBidPrice, currentPrice._2)
-      
+
     case limitAsk: LimitAskOrder =>
       val currentPrice = tradingPrices((limitAsk.withC, limitAsk.whatC))
       val newAskPrice = rules.matchingFunction(
-          marketId, limitAsk, book.asks, book.bids,
-          this.send[Streamable],
-          (a, b) => a >= b, currentPrice._2,
-          (limitAsk, askOrdersBook) => {
-            askOrdersBook insert limitAsk;
-            send(limitAsk);
-            println("MS: order enqueued")
-          })
+        marketId, limitAsk, book.asks, book.bids,
+        this.send[Streamable],
+        (a, b) => a >= b, currentPrice._2,
+        (limitAsk, askOrdersBook) => {
+          askOrdersBook insert limitAsk
+          send(limitAsk)
+          println("MS: order enqueued")
+        })
       tradingPrices((limitAsk.withC, limitAsk.whatC)) = (currentPrice._1, newAskPrice)
-      
+
     case marketBid: MarketBidOrder =>
       val currentPrice = tradingPrices((marketBid.withC, marketBid.whatC))
       val newBidPrice = rules.matchingFunction(
-          marketId, marketBid, book.bids, book.asks,
-          this.send[Streamable],
-          (a, b) => true,
-          currentPrice._1,
-          (marketBid, bidOrdersBook) => println("MS: market order discarded"))
+        marketId, marketBid, book.bids, book.asks,
+        this.send[Streamable],
+        (a, b) => true,
+        currentPrice._1,
+        (marketBid, bidOrdersBook) => println("MS: market order discarded - there is no matching order"))
       tradingPrices((marketBid.withC, marketBid.whatC)) = (newBidPrice, currentPrice._2)
-    
+
     case marketAsk: MarketAskOrder =>
       // TODO: check currencies haven't been swapped here by mistake
       val currentPrice = tradingPrices((marketAsk.withC, marketAsk.whatC))
       val newAskPrice = rules.matchingFunction(
-          marketId, marketAsk, book.asks, book.bids,
-          this.send[Streamable],
-          (a, b) => true,
-          currentPrice._2,
-          (marketAsk, askOrdersBook) => println("MS: market order discarded"))
+        marketId, marketAsk, book.asks, book.bids,
+        this.send[Streamable],
+        (a, b) => true,
+        currentPrice._2,
+        (marketAsk, askOrdersBook) => println("MS: market order discarded - there is no matching order"))
       tradingPrices((marketAsk.withC, marketAsk.whatC)) = (currentPrice._1, newAskPrice)
-    
+
     case del: DelOrder =>
       println("MS: got Delete: " + del)
       send(del)
       book delete del
-   
+
     case t: Transaction =>
       // TODO: how to know which currency of the two was bought? (Which to update, bid or ask price?)
       tradingPrices((t.withC, t.whatC)) = (???, ???)
-   
+
     case PrintBooks =>
       // print shows heap order (binary tree)
       println("Ask Orders Book: " + book.bids)
       println("Bid Orders Book: " + book.asks)
-    
+
     case _ =>
       println("MS: got unknown")
   }

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
@@ -10,6 +10,7 @@ import ch.epfl.ts.data.LimitBidOrder
 import scala.Some
 import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.data.LimitAskOrder
+import java.util.logging.Logger
 
 /**
  * Wrapper around ForexMarketRules, to have ALL the information needed to proceed the order in one method.
@@ -28,58 +29,48 @@ class FxMarketRulesWrapper(val rules :ForexMarketRules = new ForexMarketRules())
       checkPendingOrders(marketId, book, tradingPrices, send)
 
     case marketBid: MarketBidOrder =>
-      println("FMRW : received a bidOrder")
       tradingPrices.get((marketBid.withC, marketBid.whatC)) match {
-        // We buy at current ask price
         case Some(t) => rules.matchingFunction(marketId, marketBid, book.bids, book.asks, send, t._2)
         case None    =>
       }
     case marketAsk: MarketAskOrder =>
-      println("FMRW : received an askOrder")
       tradingPrices.get((marketAsk.withC, marketAsk.whatC)) match {
-        // We sell at current bid price
         case Some(t) => rules.matchingFunction(marketId, marketAsk, book.bids, book.asks, send, t._1)
         //TODO(sygi): does it actually work at all, when there are multiple currencies?
         case None    =>
       }
-    case _ =>
-      println("FMRW: got unknown order")
+    case _ => println("FMRW: got unknown order")
   }
 
   //TODO(sygi): refactor common code
   def checkPendingOrders(marketId: Long,
                          book: OrderBook, tradingPrices: mutable.HashMap[(Currency, Currency), (Double, Double)],
                          send: (Streamable) => Unit) {
-    println("FMRW: checking pending orders")
     if (!book.bids.isEmpty) {
       val topBid = book.bids.head
-      println("FMRW: topbid: " + topBid)
       tradingPrices.get((topBid.withC, topBid.whatC)) match {
         case Some(t) => {
           val askPrice = t._2
           if (askPrice <= topBid.price) {
-            //execute order right now (but on which price, actually?)
-            val order = MarketBidOrder(topBid.oid, topBid.uid, topBid.timestamp, topBid.whatC, topBid.withC, topBid.volume, topBid.price)
+            //execute order right now
+            //TODO(sygi): we put the topBid price, but it won't be used, as we ALWAYS sell/buy at the market price (from Quote))
             //TODO(sygi): Order type casting
+            val order = MarketBidOrder(topBid.oid, topBid.uid, topBid.timestamp, topBid.whatC, topBid.withC, topBid.volume, topBid.price)
             processOrder(order, marketId, book, tradingPrices, send)
-          } else
-            println("FMRW: can't yet execute order " + topBid)
+          }
         }
         case None => println("FMRW: dont have info about topBid " + topBid.withC + " " + topBid.whatC + " pair price")
       }
     }
     if (!book.asks.isEmpty) {
       val topAsk = book.asks.head
-      println("FMRW: topask: " + topAsk)
       tradingPrices.get((topAsk.withC, topAsk.whatC)) match {
         case Some(t) => {
           val bidPrice = t._2
           if (bidPrice >= topAsk.price) {
-            //execute order right now (but on which price, actually?)
             val order = MarketAskOrder(topAsk.oid, topAsk.uid, topAsk.timestamp, topAsk.whatC, topAsk.withC, topAsk.volume, topAsk.price)
             processOrder(order, marketId, book, tradingPrices, send)
-          } else
-            println("FMRW: can't yet execute order " + topAsk)
+          }
         }
         case None => println("FMRW: dont have info about " + topAsk.withC + " " + topAsk.whatC + " pair price")
       }

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
@@ -1,0 +1,90 @@
+package ch.epfl.ts.engine.rules
+
+import ch.epfl.ts.engine.{OrderBook, ForexMarketRules}
+import ch.epfl.ts.data._
+import ch.epfl.ts.data.Currency.Currency
+import scala.collection.mutable
+import scala.Some
+import ch.epfl.ts.data.MarketBidOrder
+import ch.epfl.ts.data.LimitBidOrder
+import scala.Some
+import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.data.LimitAskOrder
+
+/**
+ * Wrapper around ForexMarketRules, to have ALL the information needed to proceed the order in one method.
+ * Created by sygi on 09.05.15.
+ */
+class FxMarketRulesWrapper extends MarketRulesWrapper(new ForexMarketRules()) {
+  val rules = new ForexMarketRules()
+  override def processOrder(o: Order, marketId: Long,
+                            book: OrderBook, tradingPrices: mutable.HashMap[(Currency, Currency), (Double, Double)],
+                            send: Streamable => Unit): Unit =
+  o match {
+    case limitBid: LimitBidOrder =>
+      book.bids.insert(limitBid)
+      checkPendingOrders(marketId, book, tradingPrices, send)
+
+    case limitAsk: LimitAskOrder =>
+      book.asks.insert(limitAsk)
+      checkPendingOrders(marketId, book, tradingPrices, send)
+
+    case marketBid: MarketBidOrder =>
+      println("FMRW : received a bidOrder")
+      tradingPrices.get((marketBid.withC, marketBid.whatC)) match {
+        // We buy at current ask price
+        case Some(t) => rules.matchingFunction(marketId, marketBid, book.bids, book.asks, send, t._2)
+        case None    =>
+      }
+    case marketAsk: MarketAskOrder =>
+      println("FMRW : received an askOrder")
+      tradingPrices.get((marketAsk.withC, marketAsk.whatC)) match {
+        // We sell at current bid price
+        case Some(t) => rules.matchingFunction(marketId, marketAsk, book.bids, book.asks, send, t._1)
+        //TODO(sygi): does it actually work at all, when there are multiple currencies?
+        case None    =>
+      }
+    case _ =>
+      println("FMRW: got unknown order")
+  }
+
+  //TODO(sygi): refactor common code
+  def checkPendingOrders(marketId: Long,
+                         book: OrderBook, tradingPrices: mutable.HashMap[(Currency, Currency), (Double, Double)],
+                         send: (Streamable) => Unit) {
+    println("FMRW: checking pending orders")
+    if (!book.bids.isEmpty) {
+      val topBid = book.bids.head
+      println("FMRW: topbid: " + topBid)
+      tradingPrices.get((topBid.withC, topBid.whatC)) match {
+        case Some(t) => {
+          val askPrice = t._2
+          if (askPrice <= topBid.price) {
+            //execute order right now (but on which price, actually?)
+            val order = MarketBidOrder(topBid.oid, topBid.uid, topBid.timestamp, topBid.whatC, topBid.withC, topBid.volume, topBid.price)
+            //TODO(sygi): Order type casting
+            processOrder(order, marketId, book, tradingPrices, send)
+          } else
+            println("FMRW: can't yet execute order " + topBid)
+        }
+        case None => println("FMRW: dont have info about topBid " + topBid.withC + " " + topBid.whatC + " pair price")
+      }
+    }
+    if (!book.asks.isEmpty) {
+      val topAsk = book.asks.head
+      println("FMRW: topask: " + topAsk)
+      tradingPrices.get((topAsk.withC, topAsk.whatC)) match {
+        case Some(t) => {
+          val bidPrice = t._2
+          if (bidPrice >= topAsk.price) {
+            //execute order right now (but on which price, actually?)
+            val order = MarketAskOrder(topAsk.oid, topAsk.uid, topAsk.timestamp, topAsk.whatC, topAsk.withC, topAsk.volume, topAsk.price)
+            processOrder(order, marketId, book, tradingPrices, send)
+          } else
+            println("FMRW: can't yet execute order " + topAsk)
+        }
+        case None => println("FMRW: dont have info about " + topAsk.withC + " " + topAsk.whatC + " pair price")
+      }
+    }
+  }
+}

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
@@ -14,8 +14,7 @@ import ch.epfl.ts.data.LimitAskOrder
 /**
  * Wrapper around ForexMarketRules, to have ALL the information needed to proceed the order in one method.
  */
-class FxMarketRulesWrapper extends MarketRulesWrapper(new ForexMarketRules()) {
-  val rules = new ForexMarketRules()
+class FxMarketRulesWrapper(val rules :ForexMarketRules = new ForexMarketRules()) extends MarketRulesWrapper(rules) {
   override def processOrder(o: Order, marketId: Long,
                             book: OrderBook, tradingPrices: mutable.HashMap[(Currency, Currency), (Double, Double)],
                             send: Streamable => Unit): Unit =

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/FxMarketRulesWrapper.scala
@@ -13,7 +13,6 @@ import ch.epfl.ts.data.LimitAskOrder
 
 /**
  * Wrapper around ForexMarketRules, to have ALL the information needed to proceed the order in one method.
- * Created by sygi on 09.05.15.
  */
 class FxMarketRulesWrapper extends MarketRulesWrapper(new ForexMarketRules()) {
   val rules = new ForexMarketRules()

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/MarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/MarketRulesWrapper.scala
@@ -1,0 +1,18 @@
+package ch.epfl.ts.engine.rules
+
+import ch.epfl.ts.data.{Streamable, Order}
+import ch.epfl.ts.engine.{OrderBook, PartialOrderBook, MarketRules}
+import scala.collection.mutable.HashMap
+import ch.epfl.ts.data.Currency._
+
+/**
+ * A wrapper around the MarketRules, so that all the information needed to proceed with the order is in one place.
+ * Needed to be able to change between strategies without changing the MarketSimulator.
+ * Created by sygi on 09.05.15.
+ */
+abstract class MarketRulesWrapper(rules: MarketRules){
+  def processOrder(o: Order, marketId: Long,
+                   book: OrderBook, tradingPrices: HashMap[(Currency, Currency), (Double, Double)], //TODO(sygi): get type from original class
+                   send: Streamable => Unit)
+  def getRules = rules
+}

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/MarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/MarketRulesWrapper.scala
@@ -8,7 +8,6 @@ import ch.epfl.ts.data.Currency._
 /**
  * A wrapper around the MarketRules, so that all the information needed to proceed with the order is in one place.
  * Needed to be able to change between strategies without changing the MarketSimulator.
- * Created by sygi on 09.05.15.
  */
 abstract class MarketRulesWrapper(rules: MarketRules){
   def processOrder(o: Order, marketId: Long,

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
@@ -9,8 +9,7 @@ import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.data.LimitAskOrder
 import scala.collection.mutable.HashMap
 
-class SimulationMarketRulesWrapper() extends MarketRulesWrapper(new MarketRules()){
-  val rules = new MarketRules()
+class SimulationMarketRulesWrapper(val rules: MarketRules = new MarketRules()) extends MarketRulesWrapper(rules){
   override def processOrder(o: Order, marketId: Long,
                    book: OrderBook, tradingPrices: HashMap[(Currency, Currency), (Double, Double)],
                    send: Streamable => Unit) = {
@@ -52,7 +51,6 @@ class SimulationMarketRulesWrapper() extends MarketRulesWrapper(new MarketRules(
         tradingPrices((marketBid.withC, marketBid.whatC)) = (newBidPrice, currentPrice._2)
 
       case marketAsk: MarketAskOrder =>
-        // TODO: check currencies haven't been swapped here by mistake
         val currentPrice = tradingPrices((marketAsk.withC, marketAsk.whatC))
         val newAskPrice = rules.matchingFunction(
           marketId, marketAsk, book.asks, book.bids,

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
@@ -22,8 +22,6 @@ class SimulationMarketRulesWrapper(val rules: MarketRules = new MarketRules()) e
           (a, b) => a <= b, currentPrice._1,
           (limitBid, bidOrdersBook) => {
             bidOrdersBook insert limitBid
-            send(limitBid)
-            println("SMRW: order enqueued")
           })
         tradingPrices((limitBid.withC, limitBid.whatC)) = (newBidPrice, currentPrice._2)
 
@@ -35,8 +33,6 @@ class SimulationMarketRulesWrapper(val rules: MarketRules = new MarketRules()) e
           (a, b) => a >= b, currentPrice._2,
           (limitAsk, askOrdersBook) => {
             askOrdersBook insert limitAsk
-            send(limitAsk)
-            println("SMRW: order enqueued")
           })
         tradingPrices((limitAsk.withC, limitAsk.whatC)) = (currentPrice._1, newAskPrice)
 
@@ -47,7 +43,7 @@ class SimulationMarketRulesWrapper(val rules: MarketRules = new MarketRules()) e
           send,
           (a, b) => true,
           currentPrice._1,
-          (marketBid, bidOrdersBook) => println("SMRW: market order discarded"))
+          (marketBid, bidOrdersBook) => println("SMRW: market order discarded - there is no matching order"))
         tradingPrices((marketBid.withC, marketBid.whatC)) = (newBidPrice, currentPrice._2)
 
       case marketAsk: MarketAskOrder =>
@@ -57,7 +53,7 @@ class SimulationMarketRulesWrapper(val rules: MarketRules = new MarketRules()) e
           send,
           (a, b) => true,
           currentPrice._2,
-          (marketAsk, askOrdersBook) => println("SMRW: market order discarded"))
+          (marketAsk, askOrdersBook) => println("SMRW: market order discarded - there is no matching order"))
         tradingPrices((marketAsk.withC, marketAsk.whatC)) = (currentPrice._1, newAskPrice)
     }
   }

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
@@ -1,0 +1,69 @@
+package ch.epfl.ts.engine.rules
+
+import ch.epfl.ts.engine.{OrderBook, MarketRules}
+import ch.epfl.ts.data._
+import ch.epfl.ts.data.Currency._
+import ch.epfl.ts.data.MarketBidOrder
+import ch.epfl.ts.data.LimitBidOrder
+import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.data.LimitAskOrder
+import scala.collection.mutable.HashMap
+
+/**
+ * Created by sygi on 09.05.15.
+ */
+class SimulationMarketRulesWrapper() extends MarketRulesWrapper(new MarketRules()){
+  val rules = new MarketRules()
+  override def processOrder(o: Order, marketId: Long,
+                   book: OrderBook, tradingPrices: HashMap[(Currency, Currency), (Double, Double)],
+                   send: Streamable => Unit) = {
+    o match {
+      case limitBid: LimitBidOrder =>
+        val currentPrice = tradingPrices((limitBid.withC, limitBid.whatC))
+        val newBidPrice = rules.matchingFunction(
+          marketId, limitBid, book.bids, book.asks,
+          send,
+          (a, b) => a <= b, currentPrice._1,
+          (limitBid, bidOrdersBook) => {
+            bidOrdersBook insert limitBid
+            send(limitBid)
+            println("SMRW: order enqueued")
+          })
+        tradingPrices((limitBid.withC, limitBid.whatC)) = (newBidPrice, currentPrice._2)
+
+      case limitAsk: LimitAskOrder =>
+        val currentPrice = tradingPrices((limitAsk.withC, limitAsk.whatC))
+        val newAskPrice = rules.matchingFunction(
+          marketId, limitAsk, book.asks, book.bids,
+          send,
+          (a, b) => a >= b, currentPrice._2,
+          (limitAsk, askOrdersBook) => {
+            askOrdersBook insert limitAsk
+            send(limitAsk)
+            println("SMRW: order enqueued")
+          })
+        tradingPrices((limitAsk.withC, limitAsk.whatC)) = (currentPrice._1, newAskPrice)
+
+      case marketBid: MarketBidOrder =>
+        val currentPrice = tradingPrices((marketBid.withC, marketBid.whatC))
+        val newBidPrice = rules.matchingFunction(
+          marketId, marketBid, book.bids, book.asks,
+          send,
+          (a, b) => true,
+          currentPrice._1,
+          (marketBid, bidOrdersBook) => println("SMRW: market order discarded"))
+        tradingPrices((marketBid.withC, marketBid.whatC)) = (newBidPrice, currentPrice._2)
+
+      case marketAsk: MarketAskOrder =>
+        // TODO: check currencies haven't been swapped here by mistake
+        val currentPrice = tradingPrices((marketAsk.withC, marketAsk.whatC))
+        val newAskPrice = rules.matchingFunction(
+          marketId, marketAsk, book.asks, book.bids,
+          send,
+          (a, b) => true,
+          currentPrice._2,
+          (marketAsk, askOrdersBook) => println("SMRW: market order discarded"))
+        tradingPrices((marketAsk.withC, marketAsk.whatC)) = (currentPrice._1, newAskPrice)
+    }
+  }
+}

--- a/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
+++ b/ts/src/main/scala/ch/epfl/ts/engine/rules/SimulationMarketRulesWrapper.scala
@@ -9,9 +9,6 @@ import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.data.LimitAskOrder
 import scala.collection.mutable.HashMap
 
-/**
- * Created by sygi on 09.05.15.
- */
 class SimulationMarketRulesWrapper() extends MarketRulesWrapper(new MarketRules()){
   val rules = new MarketRules()
   override def processOrder(o: Order, marketId: Long,

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -7,13 +7,8 @@ import ch.epfl.ts.brokers.StandardBroker
 import scala.language.postfixOps
 import scala.concurrent.duration._
 import ch.epfl.ts.data._
-import ch.epfl.ts.traders.{MadTrader, MovingAverageTrader, SimpleTraderWithBroker}
-import ch.epfl.ts.data.Register
+import ch.epfl.ts.traders.MadTrader
 import ch.epfl.ts.engine._
-import ch.epfl.ts.data.MarketBidOrder
-import ch.epfl.ts.data.Register
-import ch.epfl.ts.engine.FundWallet
-import ch.epfl.ts.data.MarketAskOrder
 import ch.epfl.ts.component.fetch.{HistDataCSVFetcher, PullFetchComponent, TrueFxFetcher, MarketNames}
 import scala.reflect.ClassTag
 import ch.epfl.ts.data.Currency._
@@ -23,8 +18,6 @@ import ch.epfl.ts.engine.FundWallet
 import ch.epfl.ts.data.Quote
 import ch.epfl.ts.data.Currency
 import ch.epfl.ts.data.MarketAskOrder
-import ch.epfl.ts.component.utils.BackLoop
-import ch.epfl.ts.component.persist.DummyPersistor
 import java.util.Timer
 import ch.epfl.ts.engine.rules.{SimulationMarketRulesWrapper, FxMarketRulesWrapper}
 

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -135,7 +135,7 @@ object FullMarketSimulation {
       val workingDir = "./data"
       val currencyPair = symbol._1.toString() + symbol._2.toString();
 
-      builder.createRef(Props(classOf[HistDataCSVFetcher], workingDir, currencyPair, startDate, endDate, 4000.0), "HistDataFetcher")
+      builder.createRef(Props(classOf[HistDataCSVFetcher], workingDir, currencyPair, startDate, endDate, 1e-2), "HistDataFetcher")
     }
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -40,8 +40,9 @@ object FullMarketSimulation {
       MadTrader.CURRENCY_PAIR -> new CurrencyPairParameter(Currency.USD, Currency.CHF))
 
     val tId = 15L
+    val marketId = MarketNames.FOREX_ID
 
-    val trader = MadTrader.getInstance(tId, parameters, "OneMadTrader")
+    val trader = MadTrader.getInstance(tId, List(marketId), parameters, "OneMadTrader")
     addConsument(classOf[Quote], trader)
     val broker = builder.createRef(Props(classOf[StandardBroker]), "Broker")
     addConsument(classOf[Quote], broker)
@@ -53,13 +54,12 @@ object FullMarketSimulation {
     //fetcher
     val useLiveData = false
     val symbol = (Currency.USD, Currency.CHF)
-    val fxQuoteFetcher = createFetcher(useLiveData, builder, symbol)
 
+    val fxQuoteFetcher = createFetcher(useLiveData, builder, symbol)
     //hybrid market
     val fetcherRules = new FxMarketRulesWrapper
     val simulationRules = new SimulationMarketRulesWrapper
-    val marketForexId = MarketNames.FOREX_ID
-    val forexMarket = builder.createRef(Props(classOf[HybridMarketSimulator], marketForexId, fetcherRules, simulationRules), MarketNames.FOREX_NAME)
+    val forexMarket = builder.createRef(Props(classOf[HybridMarketSimulator], marketId, fetcherRules, simulationRules), MarketNames.FOREX_NAME)
     fxQuoteFetcher->(forexMarket, classOf[Quote])
 
     addProducer(classOf[Quote], forexMarket)

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -1,0 +1,145 @@
+package ch.epfl.ts.example
+
+import ch.epfl.ts.component.{ComponentRef, StopSignal, ComponentBuilder}
+import com.typesafe.config.ConfigFactory
+import akka.actor.Props
+import ch.epfl.ts.brokers.StandardBroker
+import scala.language.postfixOps
+import scala.concurrent.duration._
+import ch.epfl.ts.data._
+import ch.epfl.ts.traders.{MadTrader, MovingAverageTrader, SimpleTraderWithBroker}
+import ch.epfl.ts.data.Register
+import ch.epfl.ts.engine._
+import ch.epfl.ts.data.MarketBidOrder
+import ch.epfl.ts.data.Register
+import ch.epfl.ts.engine.FundWallet
+import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.component.fetch.{HistDataCSVFetcher, PullFetchComponent, TrueFxFetcher, MarketNames}
+import scala.reflect.ClassTag
+import ch.epfl.ts.data.Currency._
+import ch.epfl.ts.data.MarketBidOrder
+import ch.epfl.ts.data.Register
+import ch.epfl.ts.engine.FundWallet
+import ch.epfl.ts.data.Quote
+import ch.epfl.ts.data.Currency
+import ch.epfl.ts.data.MarketAskOrder
+import ch.epfl.ts.component.utils.BackLoop
+import ch.epfl.ts.component.persist.DummyPersistor
+import java.util.Timer
+
+/**
+ * Market simulation with first reading historical data and then running simulation on its own.
+ * Created by sygi on 08.05.15.
+ */
+object FullMarketSimulation {
+  var producers = Map[Class[_], List[ComponentRef]]()
+  var consuments = Map[Class[_], List[ComponentRef]]()
+  def main(args: Array[String]): Unit = {
+    //TODO(sygi): create functions to build components to slim main down
+    implicit val builder = new ComponentBuilder("TestingBroker", ConfigFactory.parseString("akka.loglevel = \"DEBUG\""))
+    initProducersAndConsuments()
+
+    //trader
+    val parameters = new StrategyParameters(
+      MadTrader.INITIAL_FUNDS -> WalletParameter(Map(Currency.CHF -> 1000.0)),
+      MadTrader.INTERVAL -> new TimeParameter(1 seconds),
+      MadTrader.ORDER_VOLUME -> NaturalNumberParameter(10),
+      MadTrader.CURRENCY_PAIR -> new CurrencyPairParameter(Currency.USD, Currency.CHF))
+
+    val tId = 15L
+
+    val trader = MadTrader.getInstance(tId, parameters, "OneMadTrader")
+    addConsument(classOf[Quote], trader)
+    val broker = builder.createRef(Props(classOf[StandardBroker]), "Broker")
+    addConsument(classOf[Quote], broker)
+
+    trader->(broker, classOf[Register])
+    trader->(broker, classOf[FundWallet])
+    connectAllOrders(trader, broker)
+
+    //fetcher
+    val useLiveData = true
+    val symbol = (Currency.USD, Currency.CHF)
+    val fxQuoteFetcher = createFetcher(useLiveData, builder, symbol)
+    addProducer(classOf[Quote], fxQuoteFetcher)
+
+    //market with fetcher
+    val rules = new ForexMarketRules()
+    val marketForexId = MarketNames.FOREX_ID
+    val forexMarketWithFetcher = builder.createRef(Props(classOf[MarketFXSimulator], marketForexId, rules), MarketNames.FOREX_NAME)
+
+    addConsument(classOf[Quote], forexMarketWithFetcher)
+    addProducer(classOf[Quote], forexMarketWithFetcher)
+    connectAllOrders(broker, forexMarketWithFetcher)
+    forexMarketWithFetcher->(broker, classOf[ExecutedBidOrder], classOf[ExecutedAskOrder])
+
+    //Backloop
+    val dummyPersistor = new DummyPersistor()
+    val backloop = builder.createRef(Props(classOf[BackLoop], marketForexId, dummyPersistor), "backloop")
+
+    forexMarketWithFetcher->(backloop, classOf[Transaction])
+    addProducer(classOf[Quote], backloop)
+
+    connectProducersWithConsuments()
+
+    builder.start
+    scheduleChange(fxQuoteFetcher)
+  }
+
+  def scheduleChange(quoteFetcher: ComponentRef) = {
+    val timer = new Timer()
+    class StopFetcher extends java.util.TimerTask {
+      def run() {
+        quoteFetcher.ar ! StopSignal
+      }
+    }
+    timer.schedule(new StopFetcher, 5 * 1000)
+  }
+
+  def initProducersAndConsuments() = {
+    val messageClasses = List(classOf[Quote], classOf[Transaction])
+    for(msg <- messageClasses) {
+      producers = producers + (msg -> List())
+      consuments = consuments + (msg -> List())
+    }
+  }
+
+  def addProducer(msg: Class[_], component: ComponentRef) =
+    producers = addEntity(msg, component, producers)
+
+  def addConsument(msg: Class[_], component: ComponentRef) =
+    consuments = addEntity(msg, component, consuments)
+
+  def addEntity(msg: Class[_], component: ComponentRef, mapping: Map[Class[_], List[ComponentRef]]) =
+    mapping + (msg -> (component :: mapping.getOrElse(msg, List())))
+
+  def connectProducersWithConsuments() = {
+    for(msgClass <- producers.keys){
+        for(myProducers <- producers.get(msgClass); myConsuments <- consuments.get(msgClass)) {
+          for (producer <- myProducers; consument <- myConsuments) {
+            if (producer != consument) {
+              producer ->(consument, msgClass)
+            }
+          }
+        }
+    }
+  }
+
+  def connectAllOrders(source: ComponentRef, destination: ComponentRef) =
+    source->(destination, classOf[LimitBidOrder], classOf[LimitAskOrder], classOf[MarketBidOrder], classOf[MarketAskOrder])
+
+  def createFetcher(useLiveData: Boolean, builder: ComponentBuilder, symbol: (Currency, Currency)) = {
+    if (useLiveData) {
+      val fetcherFx: TrueFxFetcher = new TrueFxFetcher
+      builder.createRef(Props(classOf[PullFetchComponent[Quote]], fetcherFx, implicitly[ClassTag[Quote]]), "TrueFxFetcher")
+    } else {
+      val dateFormat = new java.text.SimpleDateFormat("yyyyMM")
+      val startDate = dateFormat.parse("201304")
+      val endDate = dateFormat.parse("201305")
+      val workingDir = "./data"
+      val currencyPair = symbol._1.toString() + symbol._2.toString();
+
+      builder.createRef(Props(classOf[HistDataCSVFetcher], workingDir, currencyPair, startDate, endDate, 4000.0), "HistDataFetcher")
+    }
+  }
+}

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -30,7 +30,6 @@ import ch.epfl.ts.engine.rules.{SimulationMarketRulesWrapper, FxMarketRulesWrapp
 
 /**
  * Market simulation with first reading historical data and then running simulation on its own.
- * Created by sygi on 08.05.15.
  */
 object FullMarketSimulation {
   var producers = Map[Class[_], List[ComponentRef]]()

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -34,7 +34,7 @@ object FullMarketSimulation {
 
     //trader
     val parameters = new StrategyParameters(
-      MadTrader.INITIAL_FUNDS -> WalletParameter(Map(Currency.CHF -> 1000.0)),
+      MadTrader.INITIAL_FUNDS -> WalletParameter(Map(Currency.CHF -> 10000.0, Currency.USD -> 10000.0)),
       MadTrader.INTERVAL -> new TimeParameter(1 seconds),
       MadTrader.ORDER_VOLUME -> NaturalNumberParameter(10),
       MadTrader.CURRENCY_PAIR -> new CurrencyPairParameter(Currency.USD, Currency.CHF))
@@ -69,7 +69,7 @@ object FullMarketSimulation {
     connectProducersWithConsuments()
 
     builder.start
-    val delay = 10 * 1000 //in ms
+    val delay = 20 * 1000 //in ms
     scheduleChange(fxQuoteFetcher, forexMarket, delay)
   }
 

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -64,8 +64,8 @@ object FullMarketSimulation {
     addProducer(classOf[Quote], fxQuoteFetcher)
 
     //hybrid market
-    val fetcherRules = new FxMarketRulesWrapper()
-    val simulationRules = new SimulationMarketRulesWrapper()
+    val fetcherRules = new FxMarketRulesWrapper
+    val simulationRules = new SimulationMarketRulesWrapper
     val marketForexId = MarketNames.FOREX_ID
     val forexMarket = builder.createRef(Props(classOf[HybridMarketSimulator], marketForexId, fetcherRules, simulationRules), MarketNames.FOREX_NAME)
 
@@ -135,7 +135,7 @@ object FullMarketSimulation {
       val workingDir = "./data"
       val currencyPair = symbol._1.toString() + symbol._2.toString();
 
-      builder.createRef(Props(classOf[HistDataCSVFetcher], workingDir, currencyPair, startDate, endDate, 1e-2), "HistDataFetcher")
+      builder.createRef(Props(classOf[HistDataCSVFetcher], workingDir, currencyPair, startDate, endDate, 1.0), "HistDataFetcher")
     }
   }
 }

--- a/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/FullMarketSimulation.scala
@@ -29,7 +29,7 @@ object FullMarketSimulation {
   var consuments = Map[Class[_], List[ComponentRef]]()
   def main(args: Array[String]): Unit = {
     //TODO(sygi): create functions to build multiple components to slim main down
-    implicit val builder = new ComponentBuilder("TestingBroker", ConfigFactory.parseString("akka.loglevel = \"DEBUG\""))
+    implicit val builder = new ComponentBuilder
     initProducersAndConsuments()
 
     //trader
@@ -54,15 +54,14 @@ object FullMarketSimulation {
     val useLiveData = false
     val symbol = (Currency.USD, Currency.CHF)
     val fxQuoteFetcher = createFetcher(useLiveData, builder, symbol)
-    addProducer(classOf[Quote], fxQuoteFetcher)
 
     //hybrid market
     val fetcherRules = new FxMarketRulesWrapper
     val simulationRules = new SimulationMarketRulesWrapper
     val marketForexId = MarketNames.FOREX_ID
     val forexMarket = builder.createRef(Props(classOf[HybridMarketSimulator], marketForexId, fetcherRules, simulationRules), MarketNames.FOREX_NAME)
+    fxQuoteFetcher->(forexMarket, classOf[Quote])
 
-    addConsument(classOf[Quote], forexMarket)
     addProducer(classOf[Quote], forexMarket)
     connectAllOrders(broker, forexMarket)
     forexMarket->(broker, classOf[ExecutedBidOrder], classOf[ExecutedAskOrder])

--- a/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
@@ -11,7 +11,6 @@ import ch.epfl.ts.component.persist.DummyPersistor
 import ch.epfl.ts.component.fetch.MarketNames
 import ch.epfl.ts.engine.MarketFXSimulator
 import ch.epfl.ts.traders.MovingAverageTrader
-import ch.epfl.ts.component.utils.BackLoop
 import ch.epfl.ts.indicators.SmaIndicator
 import ch.epfl.ts.component.fetch.PullFetchComponent
 import ch.epfl.ts.data.{ Quote, OHLC }

--- a/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
@@ -47,7 +47,7 @@ object MovingAverageFXExample {
     val marketForexId = MarketNames.FOREX_ID
 
     val useLiveData = false
-    val symbol = (Currency.EUR, Currency.CHF)
+    val symbol = (Currency.USD, Currency.CHF)
 
     // ----- Creating actors
     // Fetcher

--- a/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
@@ -39,6 +39,7 @@ import ch.epfl.ts.data.WalletParameter
 import ch.epfl.ts.data.RealNumberParameter
 import ch.epfl.ts.component.utils.Printer
 import ch.epfl.ts.evaluation.EvaluationReport
+import ch.epfl.ts.engine.rules.FxMarketRulesWrapper
 
 object MovingAverageFXExample {
   def main(args: Array[String]): Unit = {
@@ -68,7 +69,7 @@ object MovingAverageFXExample {
       }
     }
     // Market
-    val rules = new ForexMarketRules()
+    val rules = new FxMarketRulesWrapper()
     val forexMarket = builder.createRef(Props(classOf[MarketFXSimulator], marketForexId, rules), MarketNames.FOREX_NAME)
 
     // Trader: cross moving average

--- a/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
+++ b/ts/src/main/scala/ch/epfl/ts/example/MovingAverageFXExample.scala
@@ -104,8 +104,8 @@ object MovingAverageFXExample {
 
     // ----- Connecting actors
 
-    // TODO : connect fetcher only to the market (other components will get quotes from it)
-    fxQuoteFetcher -> (Seq(forexMarket, ohlcIndicator, broker, trader), classOf[Quote])
+    fxQuoteFetcher -> (forexMarket, classOf[Quote])
+    forexMarket -> (Seq(ohlcIndicator, broker, trader), classOf[Quote])
 
     trader -> (broker, classOf[Register], classOf[FundWallet], classOf[GetWalletFunds], classOf[MarketAskOrder], classOf[MarketBidOrder])
     broker -> (forexMarket, classOf[MarketAskOrder], classOf[MarketBidOrder])

--- a/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
@@ -4,16 +4,7 @@ import scala.concurrent.duration.FiniteDuration
 import scala.util.Random
 
 import ch.epfl.ts.component.ComponentBuilder
-import ch.epfl.ts.data.CoefficientParameter
-import ch.epfl.ts.data.Currency
-import ch.epfl.ts.data.CurrencyPairParameter
-import ch.epfl.ts.data.MarketAskOrder
-import ch.epfl.ts.data.MarketBidOrder
-import ch.epfl.ts.data.NaturalNumberParameter
-import ch.epfl.ts.data.Order
-import ch.epfl.ts.data.ParameterTrait
-import ch.epfl.ts.data.StrategyParameters
-import ch.epfl.ts.data.TimeParameter
+import ch.epfl.ts.data._
 
 /**
  * Required and optional parameters used by this strategy
@@ -87,7 +78,7 @@ class MadTrader(uid: Long, parameters: StrategyParameters) extends Trader(uid, p
       alternate = alternate + 1
       orderId = orderId + 1
     }
-    case _ => println("MadTrader: received unknown")
+    case t => println("MadTrader: received unknown " + t)
   }
 
   /**

--- a/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
@@ -72,10 +72,6 @@ class MadTrader(uid: Long, marketIds : List[Long], parameters: StrategyParameter
   var price = 1.0
   override def receiver = {
     
-    case q : Quote => {
-     currentTimeMillis = q.timestamp
-    }
-    
     case SendMarketOrder => {
       // Randomize volume and price
       val variation = volumeVariation * (r.nextDouble() - 0.5) * 2.0
@@ -92,8 +88,10 @@ class MadTrader(uid: Long, marketIds : List[Long], parameters: StrategyParameter
       alternate = alternate + 1
       orderId = orderId + 1
     }
-    case q: Quote =>
+    case q: Quote => {
+      currentTimeMillis = q.timestamp
       price = q.bid
+    }
     case t => println("MadTrader: received unknown " + t)
   }
 

--- a/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/MadTrader.scala
@@ -76,14 +76,15 @@ class MadTrader(uid: Long, marketIds : List[Long], parameters: StrategyParameter
       // Randomize volume and price
       val variation = volumeVariation * (r.nextDouble() - 0.5) * 2.0
       val theVolume = ((1 + variation) * volume).toInt
-      val dummyPrice = price * (1 + variation)
+      // TODO: this is not a dummy price anymore!
+      val dummyPrice = price * (1 + 1e-3 * variation)
 
       if (alternate % 2 == 0) {
         println("MadTrader: sending limit ask order")
-        send[Order](LimitAskOrder(orderId, uid, System.currentTimeMillis(), currencies._1, currencies._2, theVolume, dummyPrice))
+        send[Order](LimitAskOrder(orderId, uid, currentTimeMillis, currencies._1, currencies._2, theVolume, dummyPrice))
       } else {
         println("MadTrader: sending limit bid order")
-        send[Order](LimitBidOrder(orderId, uid, System.currentTimeMillis(), currencies._1, currencies._2, theVolume, dummyPrice))
+        send[Order](LimitBidOrder(orderId, uid, currentTimeMillis, currencies._1, currencies._2, theVolume, dummyPrice))
       }
       alternate = alternate + 1
       orderId = orderId + 1

--- a/ts/src/main/scala/ch/epfl/ts/traders/MovingAverageTrader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/MovingAverageTrader.scala
@@ -1,29 +1,14 @@
 package ch.epfl.ts.traders
 
-import ch.epfl.ts.component.Component
 import ch.epfl.ts.indicators.MovingAverage
 import ch.epfl.ts.data.Currency._
-import ch.epfl.ts.data.{ MarketAskOrder, MarketBidOrder, Quote }
-import ch.epfl.ts.data.Currency
 import akka.actor.ActorLogging
-import ch.epfl.ts.engine.MarketFXSimulator
 import akka.actor.ActorRef
-import ch.epfl.ts.data.ConfirmRegistration
-import ch.epfl.ts.data.Register
-import ch.epfl.ts.engine.FundWallet
-import ch.epfl.ts.engine.GetWalletFunds
 import ch.epfl.ts.engine.AcceptedOrder
 import ch.epfl.ts.engine.RejectedOrder
 import ch.epfl.ts.engine.ExecutedAskOrder
 import ch.epfl.ts.engine.ExecutedBidOrder
 import scala.concurrent.duration.FiniteDuration
-import ch.epfl.ts.data.CurrencyPairParameter
-import ch.epfl.ts.data.NaturalNumberParameter
-import ch.epfl.ts.data.StrategyParameters
-import ch.epfl.ts.data.TimeParameter
-import ch.epfl.ts.data.RealNumberParameter
-import ch.epfl.ts.data.BooleanParameter
-import scala.slick.direct.order
 import akka.pattern.ask
 import ch.epfl.ts.data._
 import akka.util.Timeout
@@ -31,7 +16,6 @@ import scala.collection.mutable.{ HashMap => MHashMap }
 import ch.epfl.ts.engine.WalletFunds
 import scala.math.abs
 import scala.math.floor
-import ch.epfl.ts.engine.Wallet
 import ch.epfl.ts.engine.GetWalletFunds
 
 /**

--- a/ts/src/main/scala/ch/epfl/ts/traders/Trader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/Trader.scala
@@ -17,6 +17,7 @@ import ch.epfl.ts.data.Currency
 import ch.epfl.ts.data.WalletParameter
 import ch.epfl.ts.engine.GetTraderParameters
 import ch.epfl.ts.engine.TraderIdentity
+import ch.epfl.ts.data.TheTimeIs
 
 case class RequiredParameterMissingException(message: String) extends RuntimeException(message)
 
@@ -57,6 +58,10 @@ abstract class Trader(val uid: Long, marketIds : List[Long],val parameters: Stra
     case GetTraderParameters => {
       println("Got a GetTraderParameters")
       sender ! TraderIdentity(self.path.name, uid, companion, parameters)
+    }
+    
+    case TheTimeIs(t) => {
+      currentTimeMillis = t
     }
   }
   

--- a/ts/src/main/scala/ch/epfl/ts/traders/Trader.scala
+++ b/ts/src/main/scala/ch/epfl/ts/traders/Trader.scala
@@ -43,7 +43,7 @@ abstract class Trader(val uid: Long, marketIds : List[Long],val parameters: Stra
   
   /** Default timeout to use when Asking another component asynchronously */
   val askTimeout = 500 milliseconds
-  var currentTimeMillis : Long = 0L
+  var currentTimeMillis: Long = 0L
   
   val initialFunds = parameters.get[Map[Currency.Currency, Double]]("InitialFunds")
   

--- a/ts/src/test/scala/ch/epfl/ts/test/TestHelpers.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/TestHelpers.scala
@@ -1,7 +1,7 @@
 package ch.epfl.ts.test
 
-import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
+import scala.concurrent.duration.DurationInt
 import scala.reflect.ClassTag
 
 import org.scalatest.BeforeAndAfterAll

--- a/ts/src/test/scala/ch/epfl/ts/test/TestHelpers.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/TestHelpers.scala
@@ -14,9 +14,9 @@ import scala.reflect.ClassTag
 import akka.actor.ActorRef
 import akka.util.Timeout
 import ch.epfl.ts.component.ComponentBuilder
+import ch.epfl.ts.engine.rules.FxMarketRulesWrapper
 
 object TestHelpers {
-
   def makeTestActorSystem(name: String = "TestActorSystem") =
     ActorSystem(name, ConfigFactory.parseString(
       """
@@ -24,7 +24,6 @@ object TestHelpers {
       akka.loggers = ["akka.testkit.TestEventListener"]
       """
     ).withFallback(ConfigFactory.load()))
-  
 }
 
 /**
@@ -61,7 +60,7 @@ class SimpleBrokerWrapped(market: ActorRef) extends StandardBroker {
 /**
  * A bit dirty hack to allow ComponentRef-like communication between components, while having them in Test ActorSystem
  */
-class FxMarketWrapped(uid: Long, rules: ForexMarketRules) extends MarketFXSimulator(uid, rules) {
+class FxMarketWrapped(uid: Long, rules: ForexMarketRules) extends MarketFXSimulator(uid, new FxMarketRulesWrapper(rules)) {
   import context.dispatcher
   override def send[T: ClassTag](t: T) {
     val broker = context.actorSelection("../Broker")

--- a/ts/src/test/scala/ch/epfl/ts/test/component/BrokerInteractionTest.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/component/BrokerInteractionTest.scala
@@ -114,7 +114,7 @@ class BrokerInteractionTest
   "Wallet " should {
     " block the orders exceeding funds" in {
       within(1 second) {
-        EventFilter.debug(message = "MarketFXSimulator : received a bidOrder", occurrences = 0) intercept {
+        EventFilter.debug(message = "FxMS: received a bidOrder", occurrences = 0) intercept {
           EventFilter.debug(message = "TraderWithB: order failed", occurrences = 1) intercept {
             trader ! 'sendTooBigOrder
           }

--- a/ts/src/test/scala/ch/epfl/ts/test/component/Timekeeper.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/component/Timekeeper.scala
@@ -1,0 +1,37 @@
+package ch.epfl.ts.test.component
+
+import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import akka.actor.Props
+import ch.epfl.ts.component.utils.Timekeeper
+import ch.epfl.ts.data.TheTimeIs
+import ch.epfl.ts.test.ActorTestSuite
+import ch.epfl.ts.component.Component
+
+@RunWith(classOf[JUnitRunner])
+class TimekeeperTestSuite extends ActorTestSuite("TimekeeperTestSuite") {
+  
+  "A Timekeeper" should {
+    val base = 42L;
+	  val timePeriod = (250 milliseconds)
+	
+    val test = system.actorOf(Props(classOf[Timekeeper], testActor, base, timePeriod), "Timekeeper")
+    val offset = now
+    
+    "Send out a first timestamp right away, using the given base" in {
+     within(5 milliseconds) {
+       expectMsg(TheTimeIs(base + 1L))
+     } 
+    }
+    
+	  "Send messages periodically" in {
+		  within(2100 milliseconds) {
+        receiveN(8)
+		  }
+	  }
+    
+  }
+  
+}

--- a/ts/src/test/scala/ch/epfl/ts/test/config/FundDistributionTest.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/config/FundDistributionTest.scala
@@ -1,0 +1,37 @@
+package ch.epfl.ts.test
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FunSuite
+import ch.epfl.ts.config._
+
+@RunWith(classOf[JUnitRunner]) 
+class FundDistributionTest extends FunSuite {
+  
+  test("Local fund distribution test") {
+    val fd_USD = new FundsUSA
+//    val fd_CHF = new FundsSwitzerland
+//    val fd_RUR = new FundsRussia
+//    val fd_EUR = new FundsGermany
+//    val fd_JPY = new FundsJapan
+//    val fd_GBP = new FundsUK
+//    val fd_AUD = new FundsAustralia
+//    val fd_CAD = new FundsCanada
+    
+    val distrInPercent = List(
+        (1, 20.0),
+        (2, 20.0),
+        (3, 60.0)) // 50 % of the people own more than 2 
+    val maxVal = distrInPercent.maxBy(_._1)
+    val distr = fd_USD.percentListToDistribution(distrInPercent)
+    
+    val num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
+    val num2s = distr.foldRight(0)((elem, acc) => if (elem == 2) acc + 1 else acc)
+    val num3s = distr.foldRight(0)((elem, acc) => if (elem >= 3) acc + 1 else acc)
+    
+    assert(num1s == 1)
+    assert(num2s == 1)
+    assert(num3s == 3)
+  }  
+  
+}

--- a/ts/src/test/scala/ch/epfl/ts/test/config/FundDistributionTest.scala
+++ b/ts/src/test/scala/ch/epfl/ts/test/config/FundDistributionTest.scala
@@ -18,20 +18,67 @@ class FundDistributionTest extends FunSuite {
 //    val fd_AUD = new FundsAustralia
 //    val fd_CAD = new FundsCanada
     
-    val distrInPercent = List(
+    // 1
+    var distrInPercent = List(
+        (1, 50.0),
+        (2, 50.0))
+    var maxVal = distrInPercent.maxBy(_._1)
+    var distr = fd_USD.percentListToDistribution(distrInPercent)
+    
+    var num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
+    var num2s = distr.foldRight(0)((elem, acc) => if (elem >= 2) acc + 1 else acc)
+    
+    assert(num1s == 1)
+    assert(num2s == 1)
+    
+    
+    // 2
+    distrInPercent = List(
         (1, 20.0),
         (2, 20.0),
-        (3, 60.0)) // 50 % of the people own more than 2 
-    val maxVal = distrInPercent.maxBy(_._1)
-    val distr = fd_USD.percentListToDistribution(distrInPercent)
+        (3, 60.0)) // 60 % of the people own more than 2 
+    maxVal = distrInPercent.maxBy(_._1)
+    distr = fd_USD.percentListToDistribution(distrInPercent)
     
-    val num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
-    val num2s = distr.foldRight(0)((elem, acc) => if (elem == 2) acc + 1 else acc)
-    val num3s = distr.foldRight(0)((elem, acc) => if (elem >= 3) acc + 1 else acc)
+    num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
+    num2s = distr.foldRight(0)((elem, acc) => if (elem == 2) acc + 1 else acc)
+    var num3s = distr.foldRight(0)((elem, acc) => if (elem >= 3) acc + 1 else acc)
     
     assert(num1s == 1)
     assert(num2s == 1)
     assert(num3s == 3)
+    
+    // 3
+    distrInPercent = List(
+        (1, 1.0),
+        (2, 95.0),
+        (3, 4.0)) // 4 % of the people own more than 2 
+    maxVal = distrInPercent.maxBy(_._1)
+    distr = fd_USD.percentListToDistribution(distrInPercent)
+    
+    num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
+    num2s = distr.foldRight(0)((elem, acc) => if (elem == 2) acc + 1 else acc)
+    num3s = distr.foldRight(0)((elem, acc) => if (elem >= 3) acc + 1 else acc)
+    
+    assert(num1s == 1)
+    assert(num2s == 95)
+    assert(num3s == 4)
+    
+    // 4
+    distrInPercent = List(
+        (1, 3.0),
+        (2, 93.0),
+        (3, 4.0)) // 60 % of the people own more than 2 
+    maxVal = distrInPercent.maxBy(_._1)
+    distr = fd_USD.percentListToDistribution(distrInPercent)
+    
+    num1s = distr.foldRight(0)((elem, acc) => if (elem == 1) acc + 1 else acc)
+    num2s = distr.foldRight(0)((elem, acc) => if (elem == 2) acc + 1 else acc)
+    num3s = distr.foldRight(0)((elem, acc) => if (elem >= 3) acc + 1 else acc)
+    
+    assert(num1s == 1)
+    assert(num2s == 31)
+    assert(num3s == 1)
   }  
   
 }


### PR DESCRIPTION
Introduces `HybridMarketSimulator`, which first executes like `FxMarketSimulator` (but actually deals with the `LimitOrders`...), and after getting a `'ChangeMarketRules` message changes execution to the regular simulation (like `OrderBookMarketSimulator`. To do it, I added a class of `MarketRulesWrapper` - the _really_ self-contained MarketRules.
